### PR TITLE
SB can be configued with CRD when deployed with injector

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,4 +32,4 @@ COPY --from=mutating-webhook-service-builder \
      /go/src/github.com/cyberark/secretless-broker/sidecar-injector/cyberark-sidecar-injector \
      /usr/local/bin/
 
-ENTRYPOINT ["/usr/local/bin/cyberark-sidecar-injector", "-v=5"]
+ENTRYPOINT ["/usr/local/bin/cyberark-sidecar-injector"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,6 +14,11 @@ pipeline {
         sh './bin/build latest'
       }
     }
+    stage('Test Sidecar Injector'){
+      steps {
+        sh 'summon -f ./tests/secrets.yml ./run-tests'
+      }
+    }
 
     stage('Publish Sidecar Injector Images') {
       when {

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Create a namespace `injectors`, where you will deploy the CyberArk Sidecar Injec
     ~$ kubectl -n injectors apply -f deployment/deployment.yaml
     ~$ kubectl -n injectors apply -f deployment/service.yaml
     ~$ kubectl -n injectors apply -f deployment/mutatingwebhook-ca-bundle.yaml
+    ~$ kubectl -n injectors apply -f deployment/crd.yaml
     ```
 
 #### Verify Sidecar Injector Installation
@@ -217,13 +218,22 @@ The following table lists the configurable parameters of the Sidecar Injector an
 | `sidecar-injector.cyberark.com/conjurConnConfig` | ConfigMap holding Conjur connection configuration               |  `nil` (required for authenticator |
 | `sidecar-injector.cyberark.com/injectType` | Injected Sidecar type (`secretless` or `authenticator`)                    |  `nil` (required) |
 | `sidecar-injector.cyberark.com/containerMode` | Sidecar Container mode (`init` or `sidecar`)                  |  `nil` (only applies to authenticator) |
-| `sidecar-injector.cyberark.com/containerName` | Sidecar Container name                  |  `nil` (only applies to secretless)                              |  
+| `sidecar-injector.cyberark.com/containerName` | Sidecar Container name                  |  `nil` (only applies to authenticator)                              |
 
 #### sidecar-injector.cyberark.com/secretlessConfig
 
-Expected to contain the following path:
+There are three options for the value of secretlessConfig:
+  1. configmapName
+	1. configfile#configmapname
+	1. k8s/crd#crdName
 
+Option one is legacy, providing backwards compatibility by only specifying a configmap name.
+The general format is provider#identifier.
+
+If a config map is referenced, it should contain the following path:
 + secretless.yml - Secretless Configuration File
+
+For help using a CRD to configure secretless, Refer to the [secretless CRD readme](https://github.com/cyberark/secretless-broker/tree/master/resource-definitions).
 
 #### sidecar-injector.cyberark.com/conjurConnConfig
 
@@ -250,12 +260,12 @@ For this section, you'll work from a test namespace `$TEST_APP_NAMESPACE_NAME` (
     ```bash
     export TEST_APP_NAMESPACE_NAME=secretless-sidecar-test 
    ```
-1. Create test namespace
+2. Create test namespace
     ```bash
     ~$ kubectl create namespace ${TEST_APP_NAMESPACE_NAME}
     ```
 
-2. Label the default namespace with `cyberark-sidecar-injector=enabled`
+3. Label the default namespace with `cyberark-sidecar-injector=enabled`
     ```bash
     ~$ kubectl label \
       namespace ${TEST_APP_NAMESPACE_NAME} \
@@ -273,7 +283,7 @@ For this section, you'll work from a test namespace `$TEST_APP_NAMESPACE_NAME` (
     secretless-sidecar-test         Active    18h       enabled
     ```
 
-3. Create Secretless ConfigMap
+4. Create Secretless ConfigMap
 
     This configuration sets up an `http` listener on `0.0.0.0:3000`, with a `basic_auth` handler that retrieves user and password using the `literal` secret provider. 
    
@@ -304,7 +314,7 @@ For this section, you'll work from a test namespace `$TEST_APP_NAMESPACE_NAME` (
     EOL
     ```
 
-4. Deploy an **echo server** app with the Secretless Sidecar:
+5. Deploy an **echo server** app with the Secretless Sidecar:
    
    The app is an **echo server** listening on port **8080**, which echoes the request header of any requests sent to it. 
    
@@ -338,7 +348,7 @@ For this section, you'll work from a test namespace `$TEST_APP_NAMESPACE_NAME` (
     EOF
     ```
 
-5. Verify Secretless sidecar container injected
+6. Verify Secretless sidecar container injected
     ```bash
     ~$ kubectl -n ${TEST_APP_NAMESPACE_NAME} get pods
     ```
@@ -347,7 +357,7 @@ For this section, you'll work from a test namespace `$TEST_APP_NAMESPACE_NAME` (
     test-app                 2/2       Running       0          1m
     ```
 
-6. Test Secretless
+7. Test Secretless
 
     In this step, you test Secretless by `exec`ing into the application pod's main container and issuing an HTTP request against the echo server proxied by Secretless. 
     

--- a/bin/build
+++ b/bin/build
@@ -4,12 +4,8 @@
 # usage: ./bin/build
 set -ex
 
-if [ -z "$1" ]
-then
-    echo "tag not provided";
-    exit 1;
-fi
+tag="${1:-latest}"
 
-cd $(dirname $0)/..
+cd "$(dirname "${0}")"/..
 
-docker build -t cyberark/sidecar-injector:$1 .
+docker build -t cyberark/sidecar-injector:"${tag}" -t sidecar-injector:"${tag}" .

--- a/charts/cyberark-sidecar-injector/templates/crd.yaml
+++ b/charts/cyberark-sidecar-injector/templates/crd.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: configurations.secretless{{ .Values.SECRETLESS_CRD_SUFFIX }}.io
+spec:
+  group: secretless{{ .Values.SECRETLESS_CRD_SUFFIX }}.io
+  names:
+    kind: Configuration
+    plural: configurations
+    singular: configuration
+    shortNames:
+    - sbconfig
+  scope: Namespaced
+  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true

--- a/charts/cyberark-sidecar-injector/templates/deployment.yaml
+++ b/charts/cyberark-sidecar-injector/templates/deployment.yaml
@@ -125,7 +125,7 @@ spec:
 {{- end }}
       containers:
         - name: cyberark-sidecar-injector
-          image: cyberark/sidecar-injector:latest
+          image: {{ .Values.SidecarInjectorImage }}
           imagePullPolicy: Always
           args:
             - -tlsCertFile=/etc/webhook/certs/cert.pem
@@ -134,6 +134,9 @@ spec:
             - -alsologtostderr
             - -v=4
             - 2>&1
+          env:
+            - name: SECRETLESS_CRD_SUFFIX
+              value: "{{ .Values.SECRETLESS_CRD_SUFFIX }}"
           ports:
             - containerPort: 8080
               name: https

--- a/charts/cyberark-sidecar-injector/values.yaml
+++ b/charts/cyberark-sidecar-injector/values.yaml
@@ -14,3 +14,6 @@ fullnameOverride: ""
 csrEnabled: true
 namespaceSelectorLabel: cyberark-sidecar-injector
 # certsSecret:
+
+SidecarInjectorImage: cyberark/sidecar-injector:latest
+SECRETLESS_CRD_SUFFIX: ""

--- a/pkg/inject/authenticator.go
+++ b/pkg/inject/authenticator.go
@@ -1,80 +1,80 @@
 package inject
 
 import (
-    corev1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 type AuthenticatorSidecarConfig struct {
-    conjurConnConfigMapName string
-    conjurAuthConfigMapName string
-    containerMode           string
-    containerName           string
+	conjurConnConfigMapName string
+	conjurAuthConfigMapName string
+	containerMode           string
+	containerName           string
 }
 
 func (authConfig AuthenticatorSidecarConfig) ContainerNameOrDefault() string {
-    name := "authenticator"
-    if authConfig.containerName != "" {
-        name = authConfig.containerName
-    }
+	name := "authenticator"
+	if authConfig.containerName != "" {
+		name = authConfig.containerName
+	}
 
-    return name
+	return name
 }
 
 // generateAuthenticatorSidecarConfig generates PatchConfig from a given AuthenticatorSidecarConfig
 func generateAuthenticatorSidecarConfig(authConfig AuthenticatorSidecarConfig) *PatchConfig {
-    var containers, initContainers []corev1.Container
+	var containers, initContainers []corev1.Container
 
-    candidates := []corev1.Container{
-        {
-            Name:            authConfig.ContainerNameOrDefault() ,
-            Image:           "cyberark/conjur-kubernetes-authenticator:latest",
-            ImagePullPolicy: "IfNotPresent",
-            Env: []corev1.EnvVar{
-                envVarFromFieldPath("MY_POD_NAME", "metadata.name"),
-                envVarFromFieldPath("MY_POD_NAMESPACE", "metadata.namespace"),
-                envVarFromFieldPath("MY_POD_IP", "status.podIP"),
-                {
-                    Name: "CONJUR_AUTHN_TOKEN_FILE",
-                    Value: "/run/conjur/conjur-access-token",
-                },
-                {
-                    Name: "CONTAINER_MODE",
-                    Value: authConfig.containerMode,
-                },
-                envVarFromConfigMap("CONJUR_VERSION", authConfig.conjurConnConfigMapName),
-                envVarFromConfigMap("CONJUR_APPLIANCE_URL", authConfig.conjurConnConfigMapName),
-                envVarFromConfigMap("CONJUR_AUTHN_URL", authConfig.conjurConnConfigMapName),
-                envVarFromConfigMap("CONJUR_ACCOUNT", authConfig.conjurConnConfigMapName),
-                envVarFromConfigMap("CONJUR_SSL_CERTIFICATE", authConfig.conjurConnConfigMapName),
-                envVarFromConfigMap("CONJUR_AUTHN_LOGIN", authConfig.conjurAuthConfigMapName),
-            },
-            VolumeMounts: []corev1.VolumeMount{
-                {
-                    Name:      "conjur-access-token",
-                    MountPath: "/run/conjur",
-                },
-            },
-        },
-    }
+	candidates := []corev1.Container{
+		{
+			Name:            authConfig.ContainerNameOrDefault(),
+			Image:           "cyberark/conjur-kubernetes-authenticator:latest",
+			ImagePullPolicy: "IfNotPresent",
+			Env: []corev1.EnvVar{
+				envVarFromFieldPath("MY_POD_NAME", "metadata.name"),
+				envVarFromFieldPath("MY_POD_NAMESPACE", "metadata.namespace"),
+				envVarFromFieldPath("MY_POD_IP", "status.podIP"),
+				{
+					Name:  "CONJUR_AUTHN_TOKEN_FILE",
+					Value: "/run/conjur/conjur-access-token",
+				},
+				{
+					Name:  "CONTAINER_MODE",
+					Value: authConfig.containerMode,
+				},
+				envVarFromConfigMap("CONJUR_VERSION", authConfig.conjurConnConfigMapName),
+				envVarFromConfigMap("CONJUR_APPLIANCE_URL", authConfig.conjurConnConfigMapName),
+				envVarFromConfigMap("CONJUR_AUTHN_URL", authConfig.conjurConnConfigMapName),
+				envVarFromConfigMap("CONJUR_ACCOUNT", authConfig.conjurConnConfigMapName),
+				envVarFromConfigMap("CONJUR_SSL_CERTIFICATE", authConfig.conjurConnConfigMapName),
+				envVarFromConfigMap("CONJUR_AUTHN_LOGIN", authConfig.conjurAuthConfigMapName),
+			},
+			VolumeMounts: []corev1.VolumeMount{
+				{
+					Name:      "conjur-access-token",
+					MountPath: "/run/conjur",
+				},
+			},
+		},
+	}
 
-    if authConfig.containerMode == "init" {
-        initContainers = candidates
-    } else {
-        containers = candidates
-    }
+	if authConfig.containerMode == "init" {
+		initContainers = candidates
+	} else {
+		containers = candidates
+	}
 
-    return &PatchConfig{
-        Containers: containers,
-        InitContainers: initContainers,
-        Volumes: []corev1.Volume{
-            {
-                Name: "conjur-access-token",
-                VolumeSource: corev1.VolumeSource{
-                    EmptyDir: &corev1.EmptyDirVolumeSource{
-                        Medium:    "Memory",
-                    },
-                },
-            },
-        },
-    }
+	return &PatchConfig{
+		Containers:     containers,
+		InitContainers: initContainers,
+		Volumes: []corev1.Volume{
+			{
+				Name: "conjur-access-token",
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{
+						Medium: "Memory",
+					},
+				},
+			},
+		},
+	}
 }

--- a/pkg/inject/config.go
+++ b/pkg/inject/config.go
@@ -6,6 +6,6 @@ import (
 
 type PatchConfig struct {
 	InitContainers []corev1.Container `yaml:"initContainers"`
-	Containers []corev1.Container `yaml:"containers"`
-	Volumes    []corev1.Volume    `yaml:"volumes"`
+	Containers     []corev1.Container `yaml:"containers"`
+	Volumes        []corev1.Volume    `yaml:"volumes"`
 }

--- a/pkg/inject/constants.go
+++ b/pkg/inject/constants.go
@@ -1,12 +1,12 @@
 package inject
 
 const (
-    annotationConjurAuthConfigKey = "sidecar-injector.cyberark.com/conjurAuthConfig"
-    annotationConjurConnConfigKey = "sidecar-injector.cyberark.com/conjurConnConfig"
-    annotationContainerNameKey    = "sidecar-injector.cyberark.com/containerName"
-    annotationContainerModeKey    = "sidecar-injector.cyberark.com/containerMode"
-    annotationInjectKey           = "sidecar-injector.cyberark.com/inject"
-    annotationInjectTypeKey       = "sidecar-injector.cyberark.com/injectType"
-    annotationSecretlessConfigKey = "sidecar-injector.cyberark.com/secretlessConfig"
-    annotationStatusKey           = "sidecar-injector.cyberark.com/status"
+	annotationConjurAuthConfigKey = "sidecar-injector.cyberark.com/conjurAuthConfig"
+	annotationConjurConnConfigKey = "sidecar-injector.cyberark.com/conjurConnConfig"
+	annotationContainerNameKey    = "sidecar-injector.cyberark.com/containerName"
+	annotationContainerModeKey    = "sidecar-injector.cyberark.com/containerMode"
+	annotationInjectKey           = "sidecar-injector.cyberark.com/inject"
+	annotationInjectTypeKey       = "sidecar-injector.cyberark.com/injectType"
+	annotationSecretlessConfigKey = "sidecar-injector.cyberark.com/secretlessConfig"
+	annotationStatusKey           = "sidecar-injector.cyberark.com/status"
 )

--- a/pkg/inject/secretless.go
+++ b/pkg/inject/secretless.go
@@ -1,55 +1,122 @@
 package inject
 
 import (
-    corev1 "k8s.io/api/core/v1"
+	"os"
+	"fmt"
+	corev1 "k8s.io/api/core/v1"
+	"strings"
 )
 
 // generateSecretlessSidecarConfig generates PatchConfig from a given secretlessConfigMapName
-func generateSecretlessSidecarConfig(secretlessConfigMapName, conjurConnConfigMapName, conjurAuthConfigMapName string) *PatchConfig {
-    envvars := []corev1.EnvVar{
-        envVarFromFieldPath("MY_POD_NAME", "metadata.name"),
-        envVarFromFieldPath("MY_POD_NAMESPACE", "metadata.namespace"),
-        envVarFromFieldPath("MY_POD_IP", "status.podIP"),
-    }
+func generateSecretlessSidecarConfig(secretlessConfig, conjurConnConfigMapName, conjurAuthConfigMapName, ServiceAccountTokenVolumeName string) *PatchConfig {
+	envvars := []corev1.EnvVar{
+		envVarFromFieldPath("MY_POD_NAME", "metadata.name"),
+		envVarFromFieldPath("MY_POD_NAMESPACE", "metadata.namespace"),
+		envVarFromFieldPath("MY_POD_IP", "status.podIP"),
+		envVarFromLiteral("SECRETLESS_CRD_SUFFIX", os.Getenv("SECRETLESS_CRD_SUFFIX")),
+	}
 
-    if conjurConnConfigMapName != "" || conjurAuthConfigMapName != "" {
-        envvars = append(envvars,
-            envVarFromConfigMap("CONJUR_VERSION", conjurConnConfigMapName),
-            envVarFromConfigMap("CONJUR_APPLIANCE_URL", conjurConnConfigMapName),
-            envVarFromConfigMap("CONJUR_AUTHN_URL", conjurConnConfigMapName),
-            envVarFromConfigMap("CONJUR_ACCOUNT", conjurConnConfigMapName),
-            envVarFromConfigMap("CONJUR_SSL_CERTIFICATE", conjurConnConfigMapName),
-            envVarFromConfigMap("CONJUR_AUTHN_LOGIN", conjurAuthConfigMapName))
-    }
+	if conjurConnConfigMapName != "" || conjurAuthConfigMapName != "" {
+		envvars = append(envvars,
+			envVarFromConfigMap("CONJUR_VERSION", conjurConnConfigMapName),
+			envVarFromConfigMap("CONJUR_APPLIANCE_URL", conjurConnConfigMapName),
+			envVarFromConfigMap("CONJUR_AUTHN_URL", conjurConnConfigMapName),
+			envVarFromConfigMap("CONJUR_ACCOUNT", conjurConnConfigMapName),
+			envVarFromConfigMap("CONJUR_SSL_CERTIFICATE", conjurConnConfigMapName),
+			envVarFromConfigMap("CONJUR_AUTHN_LOGIN", conjurAuthConfigMapName))
+	}
 
-    return &PatchConfig{
-        Containers: []corev1.Container{
-            {
-                Name:            "secretless",
-                Image:           "cyberark/secretless-broker:latest",
-                Args:            []string{"-f", "/etc/secretless/secretless.yml"},
-                ImagePullPolicy: "Always",
-                VolumeMounts: []corev1.VolumeMount{
-                    {
-                        Name:      "secretless-config",
-                        ReadOnly:  true,
-                        MountPath: "/etc/secretless",
-                    },
-                },
-                Env: envvars,
-            },
-        },
-        Volumes: []corev1.Volume{
-            {
-                Name: "secretless-config",
-                VolumeSource: corev1.VolumeSource{
-                    ConfigMap: &corev1.ConfigMapVolumeSource{
-                        LocalObjectReference: corev1.LocalObjectReference{
-                            Name: secretlessConfigMapName,
-                        },
-                    },
-                },
-            },
-        },
-    }
+	// Allow configmgr#configspec in the SecretlessConfig annotation
+	var configMgr string
+	var configSpec string
+	var secretlessConfigMapName string
+	secretlessConfigPath := "/etc/secretless/secretless.yml"
+	volumes := []corev1.Volume{}
+
+	// Always add Service Account Token Volume Mount (SATVM)
+	// It shouldn't be sidecar-injector's responsibility to add the SATVM, we only
+	// do it here because the serviceaccount plugin which adds the SATVM is
+	// executed before this plugin injects the sidecar. KEP-36 will solve this
+	// ordering problem by re-running plugins after mutation. Then if we add a
+	// container, the serviceaccount plugin will reprocess the manifest and add the
+	// appropriate mount
+	//
+	// ** Remove me when KEP-36 lands **
+	// also remove common.getServiceAccountTokenVolumeName
+	// and calls to that in server.go
+	volumeMounts := []corev1.VolumeMount{
+		{
+			Name:      ServiceAccountTokenVolumeName,
+			ReadOnly:  true,
+			MountPath: "/var/run/secrets/kubernetes.io/serviceaccount",
+		},
+	}
+
+	// Three options for secretlessConfig
+	// 1. configmapName
+	// 2. configfile#configmapname
+	// 3. k8s/crd#crdName
+
+	// #2 Can't be passed straight through to the broker as its
+	// expecting configfile#fspath
+
+	if strings.Contains(secretlessConfig, "#") {
+		// configmgr#configspec
+		parts := strings.Split(secretlessConfig, "#")
+		configMgr = parts[0]
+		configSpec = parts[1]
+
+		// option 2
+		if configMgr == "configfile" {
+			secretlessConfigMapName = configSpec
+			configSpec = secretlessConfigPath
+		}
+	} else {
+		// option 1
+		// Old format, contains config map name only.
+		configMgr = "configfile"
+		secretlessConfigMapName = secretlessConfig
+		configSpec = secretlessConfigPath
+	}
+
+	// if configMgr is k8s/crd, no further config is required.
+	if configMgr == "configfile" {
+
+		// Add configmap volume
+		volumes = append(volumes, corev1.Volume{
+			Name: "secretless-config",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: secretlessConfigMapName,
+					},
+				},
+			},
+		},
+		)
+
+		// add configmap mount
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name:      "secretless-config",
+			ReadOnly:  true,
+			MountPath: "/etc/secretless",
+		},
+		)
+	}
+
+	containers := []corev1.Container{
+		{
+			Name:            "secretless",
+			Image:           "cyberark/secretless-broker:latest",
+			Args:            []string{"-config-mgr", fmt.Sprintf("%s#%s", configMgr, configSpec)},
+			ImagePullPolicy: "Always",
+			VolumeMounts:    volumeMounts,
+			Env:             envvars,
+		},
+	}
+
+	return &PatchConfig{
+		Containers: containers,
+		Volumes:    volumes,
+	}
 }

--- a/run-tests
+++ b/run-tests
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# Run tests for cyberark sidecar-injector.
+# These tests currently exercise the secrectless broker sidecar.
+
+set -euo pipefail
+cd "$(dirname "$0")"
+
+. tests/utils
+
+# Set environment variables
+UNIQUE_TEST_ID="$(uuidgen | tr "[:upper:]" "[:lower:]" | head -c 6 | tr -d -)"
+export UNIQUE_TEST_ID
+export SECRETLESS_CRD_SUFFIX="${UNIQUE_TEST_ID}"
+export SECRETLESS_CRD_SUFFIX
+export SIDECAR_IMAGE="${DOCKER_REGISTRY_PATH}/sidecar-injector:${UNIQUE_TEST_ID}"
+export SECRETLESS_IMAGE="cyberark/secretless-broker"
+export TEST_NAMESPACE="sci-${UNIQUE_TEST_ID}"
+
+
+
+function testInjection() {
+    runDockerCommand "
+    set -x
+# push the local sidecar-injector image to the remote DOCKER_REGISTRY_PATH
+docker tag 'sidecar-injector:latest' '${SIDECAR_IMAGE}' > /dev/null;
+docker push '${SIDECAR_IMAGE}' > /dev/null;
+
+export SECRETLESS_CRD_SUFFIX='${UNIQUE_TEST_ID}';
+
+# create test namespace
+kubectl create namespace '${TEST_NAMESPACE}'
+
+# switch to test namespace
+kubens '${TEST_NAMESPACE}'
+
+# run CRD tests
+cd tests;
+export SIDECAR_IMAGE='${SIDECAR_IMAGE}';
+./tests_within_docker
+"
+}
+
+function main() {
+    announce 'Build Sidecar Injector Image'
+    ./bin/build latest
+
+    docker inspect sidecar-injector:latest >/dev/null 2>&1 || {
+        echo "ERROR: sidecar-injector:latest must exist locally for test to run."
+        exit 1
+    }
+
+    announce 'Build Test Execution Docker Image'
+    prepareTestEnvironment
+
+    announce 'Test Sidecar Injection with Secretless configured via CRD'
+    testInjection
+}
+
+main

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,0 +1,28 @@
+FROM google/cloud-sdk:latest
+
+ARG HELM_VERSION=v2.10.0
+
+RUN mkdir -p /src
+WORKDIR /src
+
+# Install Helm
+RUN curl -L https://git.io/get_helm.sh | bash -s -- -v ${HELM_VERSION}
+
+# Install Docker client
+RUN apt-get update -y && \
+    apt-get install -y apt-transport-https ca-certificates curl gnupg2 software-properties-common wget && \
+    curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID")/gpg | apt-key add - && \
+    add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/$(. /etc/os-release; echo "$ID") $(lsb_release -cs) stable" && \
+    apt-get update && \
+    apt-get install -y docker-ce && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install kubectl CLI
+RUN wget -O /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.11.3/bin/linux/amd64/kubectl && \
+    chmod +x /usr/local/bin/kubectl
+
+# Install kubectx and kubens
+RUN wget -O /usr/local/bin/kubectx https://raw.githubusercontent.com/ahmetb/kubectx/master/kubectx && \
+    chmod +x /usr/local/bin/kubectx
+RUN wget -O /usr/local/bin/kubens https://raw.githubusercontent.com/ahmetb/kubectx/master/kubens && \
+    chmod +x /usr/local/bin/kubens

--- a/tests/echoserver.yaml.sh
+++ b/tests/echoserver.yaml.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+
+: "${SECRETLESS_IMAGE:?"Need to set SECRETLESS_IMAGE non-empty, and available to cluster e.g. cyberark/secretless-broker:latest"}"
+
+# returns current namespace if available, otherwise returns 'default'
+current_namespace() {
+  cur_ctx="$(kubectl config current-context)" || exit_err "error getting current context"
+  ns="$(kubectl config view -o=jsonpath="{.contexts[?(@.name==\"${cur_ctx}\")].context.namespace}")" \
+     || exit_err "error getting current namespace"
+
+  if [[ -z "${ns}" ]]; then
+    echo "default"
+  else
+    echo "${ns}"
+  fi
+}
+
+cat << EOL
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: secretless-crd
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - get
+  - watch
+  - list
+- apiGroups: [""]
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "secretless${SECRETLESS_CRD_SUFFIX}.io"
+  resources:
+  - configurations
+  verbs:
+  - get
+  - list
+  - watch
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: secretless-crd
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: secretless-crd
+subjects:
+- kind: ServiceAccount
+  name: secretless-crd
+  namespace: $(current_namespace)
+roleRef:
+  kind: ClusterRole
+  name: secretless-crd
+  apiGroup: rbac.authorization.k8s.io
+
+---
+apiVersion: "secretless${SECRETLESS_CRD_SUFFIX}.io/v1"
+kind: "Configuration"
+metadata:
+  name: crd-basic-auth-proxy
+spec:
+  listeners:
+    - name: http_config_1_listener
+      protocol: http
+      address: 0.0.0.0:8000
+
+  handlers:
+    - name: http_config_1_handler
+      type: basic_auth
+      listener: http_config_1_listener
+      match:
+        - ^http.*
+      credentials:
+        - name: username
+          provider: literal
+          id: "username"
+        - name: password
+          provider: literal
+          id: "password"
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sb-sci-echoserver
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sb-sci-echoserver
+  template:
+    metadata:
+      labels:
+        app: sb-sci-echoserver
+      annotations:
+        sidecar-injector.cyberark.com/inject: "yes"
+        sidecar-injector.cyberark.com/secretlessConfig: "k8s/crd#crd-basic-auth-proxy"
+        sidecar-injector.cyberark.com/injectType: "secretless"
+
+    spec:
+      serviceAccountName: secretless-crd
+      containers:
+      - name: echo-server
+        image: gcr.io/google_containers/echoserver:1.10
+        imagePullPolicy: Always
+      # Secretless container to be added here by sidecar injector
+EOL

--- a/tests/platform_login
+++ b/tests/platform_login
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+function main() {
+    echo "Platform Login"
+    gcloud auth activate-service-account \
+        --key-file "${GCLOUD_SERVICE_KEY}"
+
+    gcloud container clusters get-credentials \
+        "${GCLOUD_CLUSTER_NAME}" \
+        --zone "${GCLOUD_ZONE}" \
+        --project "${GCLOUD_PROJECT_NAME}"
+
+    docker login "${DOCKER_REGISTRY_URL}" \
+        -u oauth2accesstoken \
+        -p "$(gcloud auth print-access-token)"
+
+    echo "Platform Login Complete"
+}
+
+main

--- a/tests/secrets.yml
+++ b/tests/secrets.yml
@@ -1,0 +1,7 @@
+GCLOUD_CLUSTER_NAME: !var ci/google-container-engine-testbed/gcloud-cluster-name
+GCLOUD_ZONE: !var ci/google-container-engine-testbed/gcloud-zone
+GCLOUD_PROJECT_NAME: !var ci/google-container-engine-testbed/gcloud-project-name
+GCLOUD_SERVICE_KEY: !var:file ci/google-container-engine-testbed/gcloud-service-key
+
+DOCKER_REGISTRY_URL: us.gcr.io
+DOCKER_REGISTRY_PATH: us.gcr.io/conjur-gke-dev

--- a/tests/tests_within_docker
+++ b/tests/tests_within_docker
@@ -1,0 +1,280 @@
+#!/bin/bash
+
+# This script is run within a docker container that has access
+# to GKE credentials and configured clients.
+
+# 1. Deploys the sidecar injector
+# 2. Deploys a test app (echo server), which is configured to have
+#    secretless broker (SB) injected. The injected SB is configured via a CRD
+#    (custom resource definition). SB is configured to proxy http requests to
+#    the echo server, adding in a basic auth header.
+# 3. A request is made to the echo server with SB as the proxy, the test passes
+#    if a basic auth header (inserted by SB) is detected in the response from
+#    the echo server.
+
+set -exu
+set -o pipefail
+
+. ./utils
+
+# setup environment variables
+log=log.txt
+: >${log}
+export SECRETLESS_CRD_SUFFIX=${SECRETLESS_CRD_SUFFIX-}
+HELM_DEPLOYMENT="sci-${UNIQUE_TEST_ID}"
+
+# Clean up when script completes
+function cleanup() {
+    announce 'Wrapping up and removing test environment'
+
+    # Delete image from GCR
+    gcloud container images delete --force-delete-tags -q  "${SIDECAR_IMAGE}"
+
+    # Delete sci helm deployment
+    helm delete --purge "${HELM_DEPLOYMENT}"
+
+    # Delete k8s resources namespace
+    kubectl delete --wait=true --ignore-not-found=true namespace "${TEST_NAMESPACE}"
+    kubectl delete --wait=true --ignore-not-found=true namespace "i-${TEST_NAMESPACE}"
+    kubectl delete --wait=true --ignore-not-found=true crd "configurations.secretless${SECRETLESS_CRD_SUFFIX}.io" &
+
+    kubectl delete --wait=true --ignore-not-found=true service secretless-broker secretless-broker-external &
+
+    kubectl delete --wait=true --ignore-not-found=true clusterrole secretless-crd &
+    kubectl delete --wait=true --ignore-not-found=true rolebinding secretless-crd &
+    kubectl delete --wait=true --ignore-not-found=true clusterrolebinding secretless-crd &
+    kubectl delete --wait=true --ignore-not-found=true serviceaccount secretless-crd &
+
+    kubectl delete --wait=true --ignore-not-found=true deployment sb-sci-echoserver &
+    kubectl delete --wait=true --ignore-not-found=true pods -l app=sb-sci-echoserver &
+    wait
+}
+
+exit_trap() {
+    cleanup
+    printf "\n--------------------- \n\n"
+    printf "\n- exited\n\n"
+    echo 1>&2 "${1:-}"
+    if [[ -e ${log} ]]; then
+        printf "\n-- last logs\n\n"
+        cat ${log}
+        rm -rf ${log}
+    fi
+}
+trap exit_trap HUP INT QUIT TERM EXIT ERR
+
+exit_err() {
+    echo "${@}"
+    exit 1
+}
+
+function echoserver_pod_name() {
+    kubectl get pods \
+        -n "${TEST_NAMESPACE}" \
+        --field-selector=status.phase=Running \
+        -l app=sb-sci-echoserver \
+        -o jsonpath="{.items[0].metadata.name}" \
+        2>${log}
+}
+
+function echoserver_pod_ready() {
+    (kubectl -n "${TEST_NAMESPACE}" describe pod "$(echoserver_pod_name)" 2>${log} \
+        || echo "Ready False") | awk '/Ready/{if ($2 != "True") exit 1}'
+}
+
+function get_first_pod_for_app() {
+    kubectl get \
+        --namespace "$2" \
+        po -l=app="$1" \
+        -o=jsonpath='{$.items[0].metadata.name}'
+}
+
+function curl_echoserver_via_sb() {
+    kubectl -n "${TEST_NAMESPACE}" \
+        exec -i "$(echoserver_pod_name)" -c echo-server -- \
+        env http_proxy=localhost:8000 curl \
+            -v \
+            --connect-timeout 4 \
+            localhost:8080 2>${log}
+}
+function curl_echoserver() {
+    kubectl -n "${TEST_NAMESPACE}" \
+        exec -i "$(echoserver_pod_name)" -c echo-server -- curl \
+        --connect-timeout 4 \
+        localhost:8080 &>${log}
+}
+
+function wait_for_echoserver_pod() {
+    echo "waiting for pod to be ready"
+    for _ in {1..60}; do
+        echoserver_pod_ready && break
+        printf "."
+        sleep 2
+    done
+    echoserver_pod_ready || exit_err "timeout waiting for echoserver_pod_ready"
+
+    for _ in {1..60}; do
+        curl_echoserver && break
+        printf "."
+        sleep 2
+    done
+    curl_echoserver || exit_err "timeout waiting for curl_echoserver"
+
+    echo ""
+    echo "ready"
+    echo ""
+}
+
+function check_sb_injected_auth_header_present_in_echoserver_response() {
+    local username=$1
+    local password=$2
+    local resp
+    resp=$(curl_echoserver_via_sb)
+    local expected_header
+    expected_header="authorization=Basic $(printf "%s" "${username}:${password}" | base64)"
+
+    if printf "%s" "${resp}" | grep -q "${expected_header}"; then
+        echo "test passed ✔"
+    else
+        echo "expected to find '${expected_header}', in response:" >${log}
+        echo "${resp}" >>${log}
+        exit_err "test failed ✗"
+    fi
+}
+
+function deploy_echoserver() {
+    echo "deploying echoserver test app"
+
+    echo ">>--- Labeling Namespace for Sidecar Injection"
+    kubectl label \
+        namespace "${TEST_NAMESPACE}" \
+        cyberark-sidecar-injector=enabled
+
+    ./echoserver.yaml.sh >echoserver.yaml 2>${log} || exit_err "Failed to template echoserver.yaml"
+    kubectl -n "${TEST_NAMESPACE}" \
+        apply -f echoserver.yaml 2>${log} || exit_err "Failed to deploy echoserver.yaml"
+
+
+    echo "echoserver test app deployed"
+    echo ""
+}
+
+function deploy_injector() {
+    # /src --> cyberark/sidecar-injector
+    pushd /src/
+
+    I_NAMESPACE="i-${TEST_NAMESPACE}"
+    cert="${HELM_DEPLOYMENT}-cyberark-sidecar-injector.${I_NAMESPACE}"
+
+    echo ">>--- Ensure sidecar-injector namespace is clean"
+    if helm list --all |grep -q "${HELM_DEPLOYMENT}"; then
+        helm delete --purge "${HELM_DEPLOYMENT}"
+    fi
+
+    kubectl delete namespace "${I_NAMESPACE}" --ignore-not-found=true
+
+    kubectl create namespace "${I_NAMESPACE}"
+
+    echo ">>--- Deploy sidecar injection helm chart"
+    helm \
+        --namespace "${I_NAMESPACE}" \
+        --name "${HELM_DEPLOYMENT}" \
+        --set "SidecarInjectorImage=${SIDECAR_IMAGE}" \
+        --set "SECRETLESS_CRD_SUFFIX=${SECRETLESS_CRD_SUFFIX}" \
+        --set "caBundle=$(
+            kubectl -n kube-system \
+                get configmap \
+                extension-apiserver-authentication \
+                -o=jsonpath='{.data.client-ca-file}'
+        )" \
+        install \
+        charts/cyberark-sidecar-injector
+    popd
+
+    echo ">>--- Wait for CSR to be created"
+    for _ in {1..30}; do
+        # the yaml output doesn't include the condition field so -o jsonpath doesn't work here
+        kubectl \
+            -n "${I_NAMESPACE}" \
+            get "csr/${cert}" \
+            |grep Pending \
+            && break
+        sleep 1
+    done
+
+    echo ">>--- Found CSR, aproving"
+    kubectl \
+        -n "${I_NAMESPACE}" \
+        certificate approve "${cert}"
+
+    echo ">>--- Waiting for Sidecar Injector pod to initialise"
+    pod=$(get_first_pod_for_app cyberark-sidecar-injector "${I_NAMESPACE}")
+    for _ in {1..60}; do
+        status=$(kubectl -n "${I_NAMESPACE}" get "pod/${pod}" \
+                -o jsonpath="{.status.phase}"||:)
+        [[ "${status}" == "Running" ]] && break
+        sleep 1
+    done
+    echo ">>--- Sidecar Injector pod running"
+    echo ">>--- Sidecar Injector deployment complete."
+}
+
+function main() {
+    echo "using SECRETLESS_CRD_SUFFIX=${SECRETLESS_CRD_SUFFIX}"
+    echo "UTID: ${UNIQUE_TEST_ID}"
+
+    # deploy injector
+    # This creates deploys a sidecar injector pod. This listens for deployment
+    # creations and modifies them in flight to add a secretless-broker container,
+    # if the appropriate annotations are found.
+    announce "Deploying Sidecar Injector"
+    deploy_injector
+
+    # deploy secretless deps and test app (echo server)
+    # This function deploys resources required by secretless broker (RBAC, CRD)
+    # but doesn't actually deploy secretless. It does create a deployment with
+    # annotations that should cause the injector deployed in the previous step
+    # to modify the deployment and insert a secretless broker container.
+    #
+    # If the sidecar injector succesfully adds the broker to the pod,
+    # the situation will look like this:
+    #
+    #              +-----------------------------------------+
+    #              |  Test Pod                               |
+    #              |                                         |
+    #              |   +-------------+      +------------+   |
+    #              |   | Echo Server |      | Secretless |   |
+    #              |   |             |      | Broker     |   |
+    #              |   |             +<-----+            |   |
+    #              |   |             |  2   |            |   |
+    #              |   |    exec     |      |            |   |
+    # +-------------------> curl +--------->+            |   |
+    #              |   |             |  1   |            |   |
+    #              |   |             |      |            |   |
+    #              |   +-------------+      +------------+   |
+    #              |                                         |
+    #              |                                         |
+    #              +-----------------------------------------+
+    #
+    # Test scenario:
+    # the echo server is an app that requires basic auth, kubectl exec curl is
+    # an that uses echo server but doesn't know the credentials. Curl makes a
+    # request to secretless broker (1) the broker inserts a basic auth header
+    # into the requet and proxies it to the echo server (2). Echo server
+    # responds back.
+    #
+    # Echo server doesn't actually require basic auth, but because the echo
+    # server echos it's requests, we can inspect the response from the echo
+    # server to check that secretless broker injected the basic auth header.
+
+    announce "Deploying Echoserver Test Application"
+    deploy_echoserver
+    wait_for_echoserver_pod
+
+    # At this point everything is deployed, we need to make a request, that
+    # will be proxied by secretless broker and check the basic auth header.
+    announce "Verifying Deployment"
+    check_sb_injected_auth_header_present_in_echoserver_response username password
+}
+
+main

--- a/tests/utils
+++ b/tests/utils
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+#set -euo pipefail
+
+# Sets additional required environment variables that aren't available in the
+# secrets.yml file, and performs other preparatory steps
+function prepareTestEnvironment() {
+    # Prepare Docker images
+    pushd tests || exit 1
+    docker build --rm --tag "gke-utils:latest" . >/dev/null
+    popd || exit 1
+}
+
+function runDockerCommand() {
+    docker run --rm \
+      -i \
+      -e DOCKER_REGISTRY_URL \
+      -e DOCKER_REGISTRY_PATH \
+      -e GCLOUD_SERVICE_KEY="/tmp${GCLOUD_SERVICE_KEY}" \
+      -e GCLOUD_CLUSTER_NAME \
+      -e GCLOUD_ZONE \
+      -e GCLOUD_PROJECT_NAME \
+      -e SIDECAR_IMAGE \
+      -e SECRETLESS_IMAGE \
+      -e SECRETLESS_CRD_SUFFIX \
+      -e UNIQUE_TEST_ID \
+      -e TEST_NAMESPACE \
+      -v "${GCLOUD_SERVICE_KEY}:/tmp${GCLOUD_SERVICE_KEY}" \
+      -v /var/run/docker.sock:/var/run/docker.sock \
+      -v ~/.config:/root/.config \
+      -v "$PWD":/src \
+      -w /src \
+      "gke-utils:latest" \
+      bash -xec "
+        pwd
+        ./tests/platform_login > /dev/null
+        $1
+      "
+}
+
+function announce() {
+    echo "++++++++++++++++++++++++++++++++++++++"
+    echo ""
+    echo "$@"
+    echo ""
+    echo "++++++++++++++++++++++++++++++++++++++"
+}


### PR DESCRIPTION
CRD = Custom Resource Definition

This commit expands the functionality of the
"sidecar-injector.cyberark.com/secretlessConfig" annotation.

This annotation now has two forms:
1. The name of a configmap that contains a configfile
2. configmgr#configspec.

Examples of option 2:
a. k8s/crd#crdname
b. configfile/configmapname

Note that b. is different from the -config-mgr cli arg, as that
requires configfile#fspath.

This commit copies the service account token volume vmount
from an existing container in the pod to the injected pod.
This ensures that injected containers can access the k8s api.
This is a fragile hack and should be removed once KEP-36 is
implemented. That solves the plugin ordering problem at the
k8s api level, and means that sidecars added by mutating
webhooks will have service acocunt token volume mounts
added in the same way as explicitly defined containers.

Other changes:
* Reformat with gofmt
* Add Jenkinsfile and integration test
* Add CRD to helm chart and manual deployment process. Secretless
  broker will create the CRD on startup, however this is too late
  in the sidecar injection case. This is required
  when sidecar injection is used as secretless config objects need
  to be created before the secretless broker is started.

Related: #1 