### PR TITLE
Allow access to all configuration objects

### DIFF
--- a/tests/echoserver.yaml.sh
+++ b/tests/echoserver.yaml.sh
@@ -15,6 +15,12 @@ current_namespace() {
   fi
 }
 
+# list of api groups that contain configurations
+api_groups(){
+  kubectl api-resources \
+    |awk '/sbconfig/{print "  - "$3}'
+}
+
 cat << EOL
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -38,7 +44,8 @@ rules:
   - list
   - watch
 - apiGroups:
-  - "secretless${SECRETLESS_CRD_SUFFIX}.io"
+  - secretless${SECRETLESS_CRD_SUFFIX}.io
+$(api_groups)
   resources:
   - configurations
   verbs:

--- a/tests/echoserver.yaml.sh
+++ b/tests/echoserver.yaml.sh
@@ -25,7 +25,7 @@ cat << EOL
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: secretless-crd
+  name: secretless-crd-${SECRETLESS_CRD_SUFFIX}
 rules:
 - apiGroups:
   - apiextensions.k8s.io
@@ -57,20 +57,20 @@ $(api_groups)
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: secretless-crd
+  name: secretless-crd-${SECRETLESS_CRD_SUFFIX}
 
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: secretless-crd
+  name: secretless-crd-${SECRETLESS_CRD_SUFFIX}
 subjects:
 - kind: ServiceAccount
-  name: secretless-crd
+  name: secretless-crd-${SECRETLESS_CRD_SUFFIX}
   namespace: $(current_namespace)
 roleRef:
   kind: ClusterRole
-  name: secretless-crd
+  name: secretless-crd-${SECRETLESS_CRD_SUFFIX}
   apiGroup: rbac.authorization.k8s.io
 
 ---
@@ -118,7 +118,7 @@ spec:
         sidecar-injector.cyberark.com/injectType: "secretless"
 
     spec:
-      serviceAccountName: secretless-crd
+      serviceAccountName: secretless-crd-${SECRETLESS_CRD_SUFFIX}
       containers:
       - name: echo-server
         image: gcr.io/google_containers/echoserver:1.10

--- a/tests/tests_within_docker
+++ b/tests/tests_within_docker
@@ -28,10 +28,10 @@ function cleanup() {
     announce 'Wrapping up and removing test environment'
 
     # Delete image from GCR
-    gcloud container images delete --force-delete-tags -q  "${SIDECAR_IMAGE}"
+    gcloud container images delete --force-delete-tags -q  "${SIDECAR_IMAGE}" ||:
 
     # Delete sci helm deployment
-    helm delete --purge "${HELM_DEPLOYMENT}"
+    helm delete --purge "${HELM_DEPLOYMENT}" ||:
 
     # Delete k8s resources namespace
     kubectl delete --wait=true --ignore-not-found=true namespace "${TEST_NAMESPACE}"

--- a/tests/tests_within_docker
+++ b/tests/tests_within_docker
@@ -40,10 +40,9 @@ function cleanup() {
 
     kubectl delete --wait=true --ignore-not-found=true service secretless-broker secretless-broker-external &
 
-    kubectl delete --wait=true --ignore-not-found=true clusterrole secretless-crd &
-    kubectl delete --wait=true --ignore-not-found=true rolebinding secretless-crd &
-    kubectl delete --wait=true --ignore-not-found=true clusterrolebinding secretless-crd &
-    kubectl delete --wait=true --ignore-not-found=true serviceaccount secretless-crd &
+    kubectl delete --wait=true --ignore-not-found=true clusterrole "secretless-crd-${SECRETLESS_CRD_SUFFIX}" &
+    kubectl delete --wait=true --ignore-not-found=true clusterrolebinding "secretless-crd-${SECRETLESS_CRD_SUFFIX}" &
+    kubectl delete --wait=true --ignore-not-found=true serviceaccount "secretless-crd-${SECRETLESS_CRD_SUFFIX}" &
 
     kubectl delete --wait=true --ignore-not-found=true deployment sb-sci-echoserver &
     kubectl delete --wait=true --ignore-not-found=true pods -l app=sb-sci-echoserver &

--- a/tests/tests_within_docker
+++ b/tests/tests_within_docker
@@ -64,7 +64,13 @@ exit_trap() {
 trap exit_trap HUP INT QUIT TERM EXIT ERR
 
 exit_err() {
-    echo "${@}"
+    echo "Exiting with error: ${*}"
+    echo -e "\n\n*** Secretless container logs ***"
+    kubectl -n "${TEST_NAMESPACE}" logs "$(echoserver_pod_name)" -c secretless
+    echo -e "\n\n*** echo-server container logs ***"
+    kubectl -n "${TEST_NAMESPACE}" logs "$(echoserver_pod_name)" -c echo-server
+    echo -e "\n\n*** echoserver.yaml ***"
+    cat echoserver.yaml
     exit 1
 }
 


### PR DESCRIPTION
The secretless broker attempts to read all sbconfig configuration
objects. For CI tests, configuration objects are created in API
groups with unique names to avoid colloisions with other tests.
Roles and Role Bindings are used to give access to the relevant
API group for each test. However as stated previously, when
secretless uses a crd for configuration it attempts to read all
potential configuration objects, but RBAC prevents it from successfully
reading the objects that belong to api groups from other tests.

This commit modifies the test config to allow access to all
test api groups. This is not a good solution, but should improve test
reliability.

A better solution would be for secretless to only read the specific
configuration object that it needs, or only enumerate configuration
objects from a specified api group. Neither of these changes are trivial
as the ideal place for introducing the modifcations is in auto generated
code. Therefore the change will involve architectural changes to
secretless which is beyond the current scope.

Related: cyberark/sidecar-injector#4