### PR TITLE
SidecarInjectorImage with kubectl, helm chart using it as initContainer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,11 @@ RUN CGO_ENABLED=0 GOOS=linux \
 
 FROM alpine:3.8
 
-RUN apk add -u shadow libc6-compat && \
+RUN apk add -u shadow libc6-compat curl openssl && \
+    curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && \
+    chmod +x ./kubectl && \
+    mv ./kubectl /usr/local/bin/kubectl && \
+    apk del curl && \
     # Add Limited user
     groupadd -r sidecar-injector \
              -g 777 && \

--- a/charts/cyberark-sidecar-injector/templates/deployment.yaml
+++ b/charts/cyberark-sidecar-injector/templates/deployment.yaml
@@ -24,7 +24,7 @@ spec:
 {{- if .Values.csrEnabled }}
       initContainers:
         - name: init-webhook
-          image: google/cloud-sdk:alpine
+          image: {{ .Values.SidecarInjectorImage }}
           restartPolicy: Never
           command:
             - /bin/sh
@@ -32,11 +32,6 @@ spec:
           args:
             - |
               set -e
-
-              apk add openssl curl
-              curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
-              chmod +x ./kubectl
-              mv ./kubectl /usr/local/bin/kubectl
 
               secret={{ include "cyberark-sidecar-injector.fullname" . | quote }}
               service={{ include "cyberark-sidecar-injector.fullname" . | quote }}


### PR DESCRIPTION
Fixing https://github.com/cyberark/sidecar-injector/issues/11.

I've added the `kubectl` and `openssl` binaries to the `cyberark/sidecar-injector` Dockerfile so that it can be used as `initContainer` in the provided helm chart.