### PR TITLE
Add Goreleaser for automated releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ vendor/*
 deployment/mutatingwebhook-ca-bundle.yaml
 deployment/deployment.yaml
 tests/echoserver.yaml
+dist
+
+# IDE files
+.idea

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,55 @@
+project_name: cyberark-sidecar-injector
+
+builds:
+- id: cyberark-sidecar-injector-linux
+  main: ./cmd/sidecar-injector
+  env:
+  - CGO_ENABLED=0
+  # Tag 'netgo' is a Go build tag that ensures a pure Go networking stack
+  # in the resulting binary instead of using the default host's stack to
+  # ensure a fully static artifact that has no dependencies.
+  flags:
+  - -tags=netgo
+  goos:
+  - linux
+  goarch:
+  - amd64
+  # The `gitCommitShort` override is there to provide the git commit information in the
+  # final binary.
+  ldflags: -s -w -linkmode external -X github.com/cyberark/sidecar-injector/pkg/version.gitCommitShort={{ .ShortCommit }}" -extldflags "-static"
+  hooks:
+    post:
+      # Copy the binary out into the <dist> path, and give the copy the name we want
+      # in the release <extra_files>.
+      # e.g. Suppose a windows amd64 build generates a binary at
+      # path/to/secretless-broker.exe. This will be copied to
+      # path/to/../secretless-broker-windows_amd64.exe. The copy path can then be added to
+      # the release <extra_files> and will result in a release artifact with the name
+      # secretless-broker-windows_amd64.exe.
+      - cp "{{ .Path }}" "{{ dir .Path }}/../cyberark-sidecar-injector-{{.Target}}{{.Ext}}"
+
+archives:
+  - id: cyberark-sidecar-injector
+    files:
+      - CHANGELOG.md
+      - NOTICES.txt
+      - LICENSE
+    name_template: "{{.ProjectName}}_{{.Version}}_{{.Os}}_{{.Arch}}"
+    wrap_in_directory: true
+
+checksum:
+  name_template: 'SHA256SUMS.txt'
+
+dist: ./dist/goreleaser
+
+snapshot:
+  name_template: "{{ .Tag }}-next"
+
+release:
+  disable: false
+  draft: true
+  extra_files:
+    - glob: NOTICES.txt
+    - glob: LICENSE
+    - glob: dist/goreleaser/CHANGELOG.md
+    - glob: dist/goreleaser/cyberark-sidecar-injector-linux_amd64

--- a/bin/Dockerfile.releaser
+++ b/bin/Dockerfile.releaser
@@ -1,0 +1,14 @@
+FROM dockercore/golang-cross
+
+RUN apt-get update && \
+    apt-get install -y bash \
+                       build-essential \
+                       curl \
+                       docker \
+                       git \
+                       mercurial \
+                       rpm
+
+RUN curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | sh
+
+ENTRYPOINT ["goreleaser"]

--- a/bin/build_release
+++ b/bin/build_release
@@ -1,0 +1,22 @@
+#!/bin/bash -e
+
+CURRENT_DIR=$(cd $(dirname "$0"); pwd)
+
+# xgo because it allows cross-compilation
+GORELEASER_IMAGE="cyberark/goreleaser:latest-xgo"
+
+echo "Current dir: $CURRENT_DIR"
+
+# TODO: The image cyberark/goreleaser:latest-xgo will need to be pushed to Dockerhub, and
+#  the command below should become `docker pull cyberark/goreleaser:latest-xgo`
+
+# NOTE: Piping the Dockerfile sends an empty context to docker build
+docker build -t "${GORELEASER_IMAGE}" - < "$CURRENT_DIR/Dockerfile.releaser"
+
+docker run --rm -t \
+  --env GITHUB_TOKEN \
+  --volume "$CURRENT_DIR/..:/work" \
+  --workdir /work \
+  "${GORELEASER_IMAGE}" --rm-dist "$@"
+
+echo "Releases built. Archives can be found in dist/goreleaser"


### PR DESCRIPTION
Gorelease makes it possible to create build artifacts automatically. It's also capable of pushing draft releases to Github

Tested locally and used to create https://github.com/conjurinc/playroom/releases/tag/untagged-74e42214df3cea540cf0