### PR TITLE
Use project CHANGELOG as part of release files

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -51,5 +51,5 @@ release:
   extra_files:
     - glob: NOTICES.txt
     - glob: LICENSE
-    - glob: dist/goreleaser/CHANGELOG.md
+    - glob: CHANGELOG.md
     - glob: dist/goreleaser/cyberark-sidecar-injector-linux_amd64


### PR DESCRIPTION
Instead of using the CHANGELOG generated by goreleaser, containing the commits since the previous release, we'll use the project CHANGELOG which provides a cleaner description of changes. Ideally this CHANGELOG should contain only the CHANGELOG entries for the release version. However, given that we do not have automation that allows to extract the CHANGELOG entry for a release version we'll settled for the full project CHANGELOG for now.