### PR TITLE
Add ability to set Deployment apiVersion for deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Kubernetes cluster
 3. Generate sidecar injector deployment manifest
     ```bash
     ~$ ./deployment/deployment.yaml.sh \
+         --deployment-api-version apps/v1 \
          --sidecar-injector-image cyberark/sidecar-injector:latest \
          --secretless-image cyberark/secretless-broker:latest \
          --authenticator-image cyberark/conjur-kubernetes-authenticator:latest \
@@ -223,6 +224,7 @@ To install the sidecar injector in the `injectors` namespace run the following:
 ```
 helm --namespace injectors \
  install \
+ --set "deploymentApiVersion=apps/v1" \
  --set "caBundle=$(kubectl -n kube-system \
    get configmap \
    extension-apiserver-authentication \
@@ -236,13 +238,14 @@ image references, you can specify this in the `helm install` command:
 ```
 helm --namespace injectors \
  install \
+ --set "deploymentApiVersion=apps/v1" \
  --set "caBundle=$(kubectl -n kube-system \
     get configmap \
     extension-apiserver-authentication \
     -o=jsonpath='{.data.client-ca-file}' \
   )" \
- --set secretless-image=path/to/secretless/container/image/repo/and/tag" \
- --set authenticator-image=path/to/authenticator/container/image/repo/and/tag" \
+ --set secretlessImage=path/to/secretless/container/image/repo/and/tag" \
+ --set authenticatorImage=path/to/authenticator/container/image/repo/and/tag" \
  ./charts/cyberark-sidecar-injector/
 ```
 

--- a/charts/cyberark-sidecar-injector/README.md
+++ b/charts/cyberark-sidecar-injector/README.md
@@ -99,6 +99,7 @@ The following table lists the configurable parameters of the CyberArk Sidecar In
 | `sidecarInjectorImage` | Container image for the sidecar injector. | `cyberark/sidecar-injector:latest` |
 | `secretlessImage` | Container image for the Secretless sidecar. | `cyberark/secretless-broker:latest` |
 | `authenticatorImage` | Container image for the Kubernetes Authenticator sidecar. | `cyberark/conjur-kubernetes-authenticator:latest` |
+| `deploymentApiVersion` | The supported apiVersion for Deployments. This is the value that will be set in the Deployment manifest. It defaults to the supported apiVersion for Deployments on the latest Kubernetes release. | `apps/v1` |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
@@ -155,3 +156,26 @@ kubectl -n kube-system \
 ### authenticatorImage
 
 `authenticatorImage` is the container image for the Kubernetes Authenticator sidecar.
+
+### deploymentApiVersion
+
+`deploymentApiVersion` is the supported apiVersion for Deployments. This is the value that
+will be set in the Deployment manifest.
+
+`deploymentApiVersion` defaults to the supported apiVersion for Deployments on the latest
+Kubernetes release.
+
+If you're on an older version of Kubernetes, you can retrieve the supported apiVersion
+for Deployments by running the shell commands below. Update deploymentApiVersion to the
+returned.
+
+```bash
+deploymentApiGroup=$(kubectl api-resources | \
+ grep "deployments.*deploy.*Deployment" | awk '{print $3}')
+
+deploymentApiVersion=$(kubectl api-versions | grep "${deploymentApiGroup}/")
+
+echo ${deploymentApiVersion}
+```
+
+#

--- a/charts/cyberark-sidecar-injector/templates/deployment.yaml
+++ b/charts/cyberark-sidecar-injector/templates/deployment.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apps/v1beta2
+apiVersion: {{ .Values.deploymentApiVersion }}
 kind: Deployment
 metadata:
   name: {{ include "cyberark-sidecar-injector.fullname" . }}

--- a/charts/cyberark-sidecar-injector/values.yaml
+++ b/charts/cyberark-sidecar-injector/values.yaml
@@ -20,3 +20,22 @@ authenticatorImage: cyberark/conjur-kubernetes-authenticator:latest
 
 sidecarInjectorImage: cyberark/sidecar-injector:latest
 SECRETLESS_CRD_SUFFIX: ""
+
+# deploymentApiVersion is the supported apiVersion for Deployments. This is the value that
+# will be set in the Deployment manifest.
+#
+# deploymentApiVersion defaults to the supported apiVersion for Deployments on the latest
+# Kubernetes release.
+#
+# If you're on an older version of Kubernetes, you can retrieve the supported apiVersion
+# for Deployments by running the shell commands below. Update deploymentApiVersion to the
+# returned.
+#
+# deploymentApiGroup=$(kubectl api-resources | \
+# grep "deployments.*deploy.*Deployment" | awk '{print $3}')
+#
+# deploymentApiVersion=$(kubectl api-versions | grep "${deploymentApiGroup}/")
+#
+# echo ${deploymentApiVersion}
+#
+deploymentApiVersion: apps/v1

--- a/deployment/deployment.yaml.sh
+++ b/deployment/deployment.yaml.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+defaultSidecarInjectorImage="cyberark/sidecar-injector:latest"
+defaultDeploymentApiVersion="apps/v1"
+
 usage() {
     cat <<EOF
 Generate Kubernetes deployment manifest for sidecar-injector webhook service.
@@ -11,8 +14,26 @@ usage: ${0} [OPTIONS]
 The following flags are available to configure the sidecar-injector deployment. They can only take on non-empty values.
 
        --sidecar-injector-image    Container image for the Sidecar Injector.
+                                   (default: ${defaultSidecarInjectorImage})
+
        --secretless-image          Container image for the Secretless sidecar.
+
        --authenticator-image       Container image for the Kubernetes Authenticator sidecar.
+
+       --deployment-api-version    The supported apiVersion for Deployments. This is the
+                                   value that will be set in the Deployment manifest. It
+                                   defaults to the supported apiVersion for Deployments on
+                                   the latest Kubernetes release.
+
+                                   (default: ${defaultDeploymentAPIVersion})
+
+                                   If you're on an older version of Kubernetes, you can
+                                   retrieve the supported apiVersion for Deployments by
+                                   running the shell commands below.
+
+                                   deploymentApiGroup=\$(kubectl api-resources | grep "deployments.*deploy.*Deployment" | awk '{print \$3}')
+                                   deploymentApiVersion=\$(kubectl api-versions | grep "\${deploymentApiGroup}/")
+                                   echo "\${deploymentApiVersion}"
 EOF
     exit 1
 }
@@ -24,10 +45,16 @@ usage_if_empty() {
   fi
 }
 
-sidecarInjectorImage="cyberark/sidecar-injector:latest"
+sidecarInjectorImage="${defaultSidecarInjectorImage}"
+deploymentApiVersion="${defaultDeploymentAPIVersion}"
 
 while [[ $# -gt 0 ]]; do
     case ${1} in
+        --deployment-api-version)
+            usage_if_empty "$2"
+            deploymentApiVersion="$2"
+            shift
+            ;;
         --sidecar-injector-image)
             usage_if_empty "$2"
             sidecarInjectorImage="$2"
@@ -51,7 +78,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 cat << EOL
-apiVersion: extensions/v1beta1
+apiVersion: ${deploymentApiVersion}
 kind: Deployment
 metadata:
   name: cyberark-sidecar-injector
@@ -59,6 +86,9 @@ metadata:
     app: cyberark-sidecar-injector
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: cyberark-sidecar-injector
   template:
     metadata:
       labels:

--- a/tests/tests_within_docker
+++ b/tests/tests_within_docker
@@ -184,6 +184,7 @@ function deploy_injector() {
     helm \
         --namespace "${I_NAMESPACE}" \
         --name "${HELM_DEPLOYMENT}" \
+        --set "deploymentApiVersion=apps/v1" \
         --set "SECRETLESS_CRD_SUFFIX=${SECRETLESS_CRD_SUFFIX}" \
         --set "sidecarInjectorImage=${SIDECAR_IMAGE}" \
         --set "caBundle=$(


### PR DESCRIPTION
The supported apiVersion for Deployments depends on the cluster. Errors occur due to apiVersion mismatch. For this reason we give the user the choice to specify while applying sensible defaults