### PR TITLE
Upgrade from Helm V2 support to Helm V3 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Dropped support for Helm V2 and converted to Helm V3.
+  [#60](https://github.com/cyberark/sidecar-injector/pull/60)
+
 ## [0.1.1] - 2020-06-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Kubernetes cluster
 
 ### Installing the Sidecar Injector (Helm)
 
-+ [Helm v2](https://v2.helm.sh/docs/) is **required**
++ [Helm v3](https://helm.sh/docs/) is **required**
 
 To install the sidecar injector in the `injectors` namespace run the following:
 

--- a/charts/cyberark-sidecar-injector/README.md
+++ b/charts/cyberark-sidecar-injector/README.md
@@ -15,7 +15,7 @@ CyberArk Sidecar Injector is a [MutatingAdmissionWebhook](https://kubernetes.io/
 ## TL;DR;
 
 ```bash
-$ helm install -f values.yaml .
+$ helm install -f values.yaml my-release .
 ```
 
 ## Introduction
@@ -35,13 +35,14 @@ Supporting TLS for external webhook server is required because admission is a hi
 To install the chart with the release name `my-release`, follow the instructions in the NOTES section on how to approve the CSR:
 
 ```bash
-$ helm install --name my-release \
+$ helm install \
   --set caBundle="$(kubectl -n kube-system \
     get configmap \
     extension-apiserver-authentication \
     -o=jsonpath='{.data.client-ca-file}' \
   )" \
- .
+  my-release \
+  .
 ```
 
 ```
@@ -104,10 +105,11 @@ The following table lists the configurable parameters of the CyberArk Sidecar In
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```bash
-$ helm install --name my-release \
+$ helm install \
    --set csrEnabled="false" \
    --set certsSecret="some-secret" \
    --set caBundle="-----BEGIN CERTIFICATE-----..." \
+   my-release \
    .
 ```
 
@@ -116,7 +118,7 @@ The above command creates a sidecar injector deployment, retrieves the private k
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
 ```bash
-$ helm install --name my-release -f values.yaml .
+$ helm install -f values.yaml my-release .
 ```
 
 ### certsSecret

--- a/charts/cyberark-sidecar-injector/templates/deployment.yaml
+++ b/charts/cyberark-sidecar-injector/templates/deployment.yaml
@@ -25,7 +25,6 @@ spec:
       initContainers:
         - name: init-webhook
           image: {{ .Values.sidecarInjectorImage }}
-          restartPolicy: Never
           command:
             - /bin/sh
             - -c

--- a/charts/cyberark-sidecar-injector/values.yaml
+++ b/charts/cyberark-sidecar-injector/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-# helm install --namespace default --name meow .
+# helm install --namespace default meow .
 #
 
 replicaCount: 1

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,12 +1,14 @@
 FROM google/cloud-sdk:latest
 
-ARG HELM_VERSION=v2.10.0
+ARG HELM_VERSION
 
 RUN mkdir -p /src
 WORKDIR /src
 
-# Install Helm
-RUN curl -L https://git.io/get_helm.sh | bash -s -- -v ${HELM_VERSION}
+# Install Helm client
+RUN curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
+RUN chmod 700 get_helm.sh
+RUN ./get_helm.sh --no-sudo --version ${HELM_VERSION:-v3.7.0}
 
 # Install Docker client
 RUN apt-get update -y && \

--- a/tests/tests_within_docker
+++ b/tests/tests_within_docker
@@ -31,7 +31,7 @@ function cleanup() {
     gcloud container images delete --force-delete-tags -q  "${SIDECAR_IMAGE}" ||:
 
     # Delete sci helm deployment
-    helm delete --purge "${HELM_DEPLOYMENT}" ||:
+    helm uninstall "${HELM_DEPLOYMENT}" ||:
 
     # Delete k8s resources namespace
     kubectl delete --wait=true --ignore-not-found=true namespace "${TEST_NAMESPACE}"
@@ -173,7 +173,7 @@ function deploy_injector() {
 
     echo ">>--- Ensure sidecar-injector namespace is clean"
     if helm list --all |grep -q "${HELM_DEPLOYMENT}"; then
-        helm delete --purge "${HELM_DEPLOYMENT}"
+        helm uninstall "${HELM_DEPLOYMENT}"
     fi
 
     kubectl delete namespace "${I_NAMESPACE}" --ignore-not-found=true
@@ -183,7 +183,6 @@ function deploy_injector() {
     echo ">>--- Deploy sidecar injection helm chart"
     helm \
         --namespace "${I_NAMESPACE}" \
-        --name "${HELM_DEPLOYMENT}" \
         --set "deploymentApiVersion=apps/v1" \
         --set "SECRETLESS_CRD_SUFFIX=${SECRETLESS_CRD_SUFFIX}" \
         --set "sidecarInjectorImage=${SIDECAR_IMAGE}" \
@@ -194,6 +193,7 @@ function deploy_injector() {
                 -o=jsonpath='{.data.client-ca-file}'
         )" \
         install \
+        "${HELM_DEPLOYMENT}" \
         charts/cyberark-sidecar-injector
     popd
 


### PR DESCRIPTION
### What does this PR do?

Helm v2 is no longer officially supported by the Helm community (see https://helm.sh/blog/helm-v2-deprecation-timeline/) by the Helm), so support for Helm V2 by the Sidecar Injector Helm chart is being dropped in favor of Helm V3.

The current, latest supported Helm version is now Helm v3.7.0.

### What ticket does this PR close?

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation