### PR TITLE
Add schema for secretless CRD

### DIFF
--- a/charts/cyberark-sidecar-injector/templates/crd.yaml
+++ b/charts/cyberark-sidecar-injector/templates/crd.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: configurations.secretless{{ .Values.SECRETLESS_CRD_SUFFIX }}.io
@@ -10,9 +10,63 @@ spec:
     plural: configurations
     singular: configuration
     shortNames:
-    - sbconfig
+      - sbconfig
   scope: Namespaced
   versions:
     - name: v1
       served: true
       storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                listeners:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      protocol:
+                        type: string
+                      socket:
+                        type: string
+                      address:
+                        type: string
+                      debug:
+                        type: boolean
+                      caCertFiles:
+                        type: array
+                        items:
+                          type: string
+                handlers:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      type:
+                        type: string
+                      listener:
+                        type: string
+                      debug:
+                        type: boolean
+                      match:
+                        type: array
+                        items:
+                          type: string
+                      credentials:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            provider:
+                              type: string
+                            id:
+                              type: string

--- a/deployment/crd.yaml
+++ b/deployment/crd.yaml
@@ -2,7 +2,7 @@
 # SB via a CRD, then the CRD has to exist prior to SB starting.
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: configurations.secretless.io
@@ -13,9 +13,63 @@ spec:
     plural: configurations
     singular: configuration
     shortNames:
-    - sbconfig
+      - sbconfig
   scope: Namespaced
   versions:
     - name: v1
       served: true
       storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                listeners:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      protocol:
+                        type: string
+                      socket:
+                        type: string
+                      address:
+                        type: string
+                      debug:
+                        type: boolean
+                      caCertFiles:
+                        type: array
+                        items:
+                          type: string
+                handlers:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      type:
+                        type: string
+                      listener:
+                        type: string
+                      debug:
+                        type: boolean
+                      match:
+                        type: array
+                        items:
+                          type: string
+                      credentials:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            provider:
+                              type: string
+                            id:
+                              type: string


### PR DESCRIPTION
### Desired Outcome

One of the ways that the CyberArk Secretless Broker (SB) can be configured is by using a Kubernetes Custom Resource Definition (CRD) that is specifically created for SB Configuration. This method of configuration is documented [here](https://github.com/cyberark/secretless-broker/tree/main/resource-definitions).

Currently, our documentation suggests that users should deploy these CRDs using the `{{apiextensions.k8s.io/v1beta1}}`
Kubernetes API version. However, support for this API version has been _*fully removed*_ in Kubernetes API controllers as of Kubernetes v1.22.

This full deprecation is documented here:
https://kubernetes.io/docs/reference/using-api/deprecation-guide/#customresourcedefinition-v122

For context, the Kubernetes Release history can be found here:
https://kubernetes.io/releases/

This means that any customers who want to use the Secretless Broker in Kubernetes clusters that are v1.22 or newer (or, correspondingly OpenShift v4.9 or newer) must create CRDs using the `v1` API version, that is, `apiextensions.k8s.io/v1`.

However, for this `v1` API version, the CRD specifications must include a structural schema as described here:
https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#specifying-a-structural-schema

An example of a CRD manifest that contains a structural schema is here:
https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#create-a-customresourcedefinition

Note that the Cyberark Sidecar Injector uses a Secretless CRD to configure an injected Secretless Broker sidecar:
https://github.com/cyberark/sidecar-injector/blob/main/charts/cyberark-sidecar-injector/templates/crd.yaml

And here is a corresponding CR manifest for that CRD:
https://github.com/cyberark/sidecar-injector/blob/main/tests/echoserver.yaml.sh#L75-L97

We need to:
- Upgrade our documentation for Secretless Broker to use the newer `v1` API version.
- Figure out a general-purpose schema that we can include in the CRD definitions in our documentation.
- Add this schema to our Secretless Broker E2E tests
- Add the appropriate schema to the Sidecar Injector E2E tests.

As a followup, we may want to *eventually* consider adding Validation rules. See https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#validation-rules

However Validation rules are only supported until Kubernetes v1.23 or newer.|https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#validation-rules),]

### Implemented Changes

*Describe how the desired outcome above has been achieved with this PR. In
particular, consider:*

- _What's changed? Why were these changes made?_
- _How should the reviewer approach this PR, especially if manual tests are required?_
- _Are there relevant screenshots you can add to the PR description?_

### Connected Issue/Story

CyberArk internal issue link: [ONYX-14759](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-14759)

### Definition of Done

- [x] Figure out a general-purpose schema that we can include in the CRD definitions in our documentation.
- [x] Add the appropriate schema to the Sidecar Injector E2E tests.

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
