### PR TITLE
Renaming the configurable parameters on sidecar-injector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Dropped support for Helm V2 and converted to Helm V3.
-  [#60](https://github.com/cyberark/sidecar-injector/pull/60)
+  [cyberark/sidecar-injector#60](https://github.com/cyberark/sidecar-injector/pull/60)
 - K8s APIs used for mutating webhook request/response messages are upgraded
   from the deprecated 'v1beta1' versions to 'v1' so that the Sidecar Injector
   works on Kubernetes v1.22 or newer and OpenShift v4.9 or newer.
-  [#62](https://github.com/cyberark/sidecar-injector/pull/62)
+  [cyberark/sidecar-injector#62](https://github.com/cyberark/sidecar-injector/pull/62)
+- BREAKING CHANGE: Changed annotations to be consistent with other Cyberark repositories.
+  sidecar-injector.cyberark.com is changed to conjur.org
+  All user manifests must be changed to use the new annotations. [cyberark/sidecar-injector#70](https://github.com/cyberark/sidecar-injector/pull/70)
 
 ### Security
 - Added replace statements to go.mod to remove vulnerable dependency versions from the dependency tree

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ object.
     + [Installing the Sidecar Injector (Helm)](#installing-the-sidecar-injector-helm)
   * [Using the Sidecar Injector](#using-the-sidecar-injector)
     + [Configuration](#configuration)
-      - [sidecar-injector.cyberark.com/secretlessConfig](#sidecar-injectorcyberarkcomsecretlessconfig)
-      - [sidecar-injector.cyberark.com/conjurConnConfig](#sidecar-injectorcyberarkcomconjurconnconfig)
-      - [sidecar-injector.cyberark.com/conjurAuthConfig](#sidecar-injectorcyberarkcomconjurauthconfig)
+      - [conjur.org/secretlessConfig](#conjurorgsecretlessconfig)
+      - [conjur.org/conjurConnConfig](#conjurorgconjurconnconfig)
+      - [conjur.org/conjurAuthConfig](#conjurorgconjurauthconfig)
   * [Secretless Sidecar Injection Example](#secretless-sidecar-injection-example)
   * [Conjur Authenticator/Secretless Sidecar Injection Example](#conjur-authenticatorsecretless-sidecar-injection-example)
     + [Deploy Authenticator Sidecar](#deploy-authenticator-sidecar)
@@ -290,25 +290,31 @@ on how to accept the CSR request. The CSR request **must** be approved.
 
 The configurable parameters should be set as annotations on the **Pod template spec** and
 *NOT on the Deployment, Job or otherwise**. The sidecar injector will not inject the
-sidecar into pods by default. Add the `sidecar-injector.cyberark.com/inject` annotation
+sidecar into pods by default. Add the `conjur.org/inject` annotation
 with value `true` to the **Pod template spec** to enable injection. Injection will not go
 ahead if the annotations are not on the **Pod template spec**.
+
+**Note:** Configurable parameters of the Sidecar Injector have changed!
+
+For Sidecar injector versions 0.1.1 and below the parameters used `sidecar-injector.cyberark.com/xxx`.
+This has been updated to `conjur.org/xxx` in version 0.2.0 and above.
+
 
 The following table lists the configurable parameters of the Sidecar Injector and their
 default values.
 
 | Parameter                     | Description                                     | Default                                                    |
 | -----------------------       | ---------------------------------------------   | ---------------------------------------------------------- |
-| `sidecar-injector.cyberark.com/inject`| Enable the Sidecar Injector by setting to `true`            | `nil` (required) |
-| `sidecar-injector.cyberark.com/secretlessConfig` | ConfigMap holding Secretless configuration               |  `nil` (required for secretless)  |  
-| `sidecar-injector.cyberark.com/conjurAuthConfig` | ConfigMap holding Conjur authentication configuration            |  `nil` (required for authenticator |
-| `sidecar-injector.cyberark.com/conjurConnConfig` | ConfigMap holding Conjur connection configuration               |  `nil` (required for authenticator |
-| `sidecar-injector.cyberark.com/injectType` | Injected Sidecar type (`secretless` or `authenticator`)                    |  `nil` (required) |
-| `sidecar-injector.cyberark.com/conjurTokenReceivers` | Comma-separated list of the names of containers, in the pod, that will be injected with `conjur-access-token` VolumeMounts. (e.g. `app-container-1,app-container-2`)                  |  `nil` (only applies to authenticator) |
-| `sidecar-injector.cyberark.com/containerMode` | Sidecar Container mode (`init` or `sidecar`)                  |  `nil` (only applies to authenticator) |
-| `sidecar-injector.cyberark.com/containerName` | Sidecar Container name                  |  `nil` (only applies to authenticator)                              |
+| `conjur.org/inject`| Enable the Sidecar Injector by setting to `true`            | `nil` (required) |
+| `conjur.org/secretlessConfig` | ConfigMap holding Secretless configuration               |  `nil` (required for secretless)  |
+| `conjur.org/conjurAuthConfig` | ConfigMap holding Conjur authentication configuration            |  `nil` (required for authenticator |
+| `conjur.org/conjurConnConfig` | ConfigMap holding Conjur connection configuration               |  `nil` (required for authenticator |
+| `conjur.org/injectType` | Injected Sidecar type (`secretless` or `authenticator`)                    |  `nil` (required) |
+| `conjur.org/conjurTokenReceivers` | Comma-separated list of the names of containers, in the pod, that will be injected with `conjur-access-token` VolumeMounts. (e.g. `app-container-1,app-container-2`)                  |  `nil` (only applies to authenticator) |
+| `conjur.org/containerMode` | Sidecar Container mode (`init` or `sidecar`)                  |  `nil` (only applies to authenticator) |
+| `conjur.org/containerName` | Sidecar Container name                  |  `nil` (only applies to authenticator)                              |
 
-#### sidecar-injector.cyberark.com/secretlessConfig
+#### conjur.org/secretlessConfig
 
 There are three options for the value of secretlessConfig:
   1. configmapName
@@ -324,7 +330,7 @@ If a config map is referenced, it should contain the following path:
 For help using a CRD to configure secretless, Refer to the [secretless CRD readme](
 https://github.com/cyberark/secretless-broker/tree/main/resource-definitions).
 
-#### sidecar-injector.cyberark.com/conjurConnConfig
+#### conjur.org/conjurConnConfig
 
 Expected to contain the following paths:
 
@@ -334,7 +340,7 @@ Expected to contain the following paths:
 + CONJUR_ACCOUNT - the account name for the Conjur instance you are connecting to
 + CONJUR_SSL_CERTIFICATE - the x509 certificate that was created when Conjur was initiated
 
-#### sidecar-injector.cyberark.com/conjurAuthConfig
+#### conjur.org/conjurAuthConfig
 
 Expected to contain the following path:
 
@@ -422,9 +428,9 @@ to allow the cyberark-sidecar-injector to operate on pods created in this namesp
     metadata:
       name: test-app
       annotations:
-        sidecar-injector.cyberark.com/inject: "yes"
-        sidecar-injector.cyberark.com/secretlessConfig: "secretless"
-        sidecar-injector.cyberark.com/injectType: "secretless"
+        conjur.org/inject: "yes"
+        conjur.org/secretlessConfig: "secretless"
+        conjur.org/injectType: "secretless"
       labels:
         app: test-app
     spec:
@@ -602,7 +608,7 @@ communicate with the Conjur appliance.
 sidecar injector. The injection is configured via annotations. 
     
     + The `conjur` ConfigMap is used for both Conjur Authentication and Connection configuration
-    + The `sidecar-injector.cyberark.com/containerName` is set to "secretless" because the
+    + The `conjur.org/containerName` is set to "secretless" because the
 corresponding Conjur identity to the service account used expects the sidecar container to
 be named secretless.
 
@@ -616,13 +622,13 @@ be named secretless.
     kind: Pod
     metadata:
       annotations:
-        sidecar-injector.cyberark.com/conjurAuthConfig: conjur
-        sidecar-injector.cyberark.com/conjurConnConfig: conjur
-        sidecar-injector.cyberark.com/containerMode: ${containerMode}
-        sidecar-injector.cyberark.com/conjurTokenReceivers: "app"
-        sidecar-injector.cyberark.com/inject: "yes"
-        sidecar-injector.cyberark.com/injectType: authenticator
-        sidecar-injector.cyberark.com/containerName: secretless
+        conjur.org/conjurAuthConfig: conjur
+        conjur.org/conjurConnConfig: conjur
+        conjur.org/containerMode: ${containerMode}
+        conjur.org/conjurTokenReceivers: "app"
+        conjur.org/inject: "yes"
+        conjur.org/injectType: authenticator
+        conjur.org/containerName: secretless
       labels:
         app: test-app
       name: test-app
@@ -651,7 +657,7 @@ be named secretless.
     The `/run/conjur/access-token` file contains the access token which is injected by the
     **Authenticator** sidecar upon successful authentication against the Conjur appliance.
     Note that this file is volume mounted into the application pod's main container as a
-    result of the annotation `sidecar-injector.cyberark.com/conjurTokenReceivers` being
+    result of the annotation `conjur.org/conjurTokenReceivers` being
     set to that container's name.
 
     ```bash
@@ -723,11 +729,11 @@ be named secretless.
     kind: Pod
     metadata:
       annotations:
-        sidecar-injector.cyberark.com/conjurAuthConfig: conjur
-        sidecar-injector.cyberark.com/conjurConnConfig: conjur
-        sidecar-injector.cyberark.com/inject: "yes"
-        sidecar-injector.cyberark.com/injectType: secretless
-        sidecar-injector.cyberark.com/secretlessConfig: secretless
+        conjur.org/conjurAuthConfig: conjur
+        conjur.org/conjurConnConfig: conjur
+        conjur.org/inject: "yes"
+        conjur.org/injectType: secretless
+        conjur.org/secretlessConfig: secretless
       labels:
         app: test-app
       name: test-app

--- a/charts/cyberark-sidecar-injector/templates/mutatingwebhook.yaml
+++ b/charts/cyberark-sidecar-injector/templates/mutatingwebhook.yaml
@@ -8,7 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 webhooks:
-  - name: sidecar-injector.cyberark.com
+  - name: sidecar-injector.conjur.org
     clientConfig:
       service:
         name: {{ include "cyberark-sidecar-injector.name" . | quote }}

--- a/deployment/mutatingwebhook.yaml
+++ b/deployment/mutatingwebhook.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: cyberark-sidecar-injector
 webhooks:
-  - name: sidecar-injector.cyberark.com
+  - name: sidecar-injector.conjur.org
     clientConfig:
       service:
         name: ${service}

--- a/pkg/inject/constants.go
+++ b/pkg/inject/constants.go
@@ -1,14 +1,14 @@
 package inject
 
 const (
-	annotationConjurAuthConfigKey     = "sidecar-injector.cyberark.com/conjurAuthConfig"
-	annotationConjurConnConfigKey     = "sidecar-injector.cyberark.com/conjurConnConfig"
-	annotationContainerNameKey        = "sidecar-injector.cyberark.com/containerName"
-	annotationContainerModeKey        = "sidecar-injector.cyberark.com/containerMode"
-	annotationConjurTokenReceiversKey = "sidecar-injector.cyberark.com/conjurTokenReceivers"
-	annotationInjectKey               = "sidecar-injector.cyberark.com/inject"
-	annotationInjectTypeKey           = "sidecar-injector.cyberark.com/injectType"
-	annotationSecretlessConfigKey     = "sidecar-injector.cyberark.com/secretlessConfig"
-	annotationSecretlessCRDSuffixKey  = "sidecar-injector.cyberark.com/secretlessCRDSuffix"
-	annotationStatusKey               = "sidecar-injector.cyberark.com/status"
+	annotationConjurAuthConfigKey     = "conjur.org/conjurAuthConfig"
+	annotationConjurConnConfigKey     = "conjur.org/conjurConnConfig"
+	annotationContainerNameKey        = "conjur.org/containerName"
+	annotationContainerModeKey        = "conjur.org/containerMode"
+	annotationConjurTokenReceiversKey = "conjur.org/conjurTokenReceivers"
+	annotationInjectKey               = "conjur.org/inject"
+	annotationInjectTypeKey           = "conjur.org/injectType"
+	annotationSecretlessConfigKey     = "conjur.org/secretlessConfig"
+	annotationSecretlessCRDSuffixKey  = "conjur.org/secretlessCRDSuffix"
+	annotationStatusKey               = "conjur.org/status"
 )

--- a/pkg/inject/testdata/authenticator-annotated-pod.json
+++ b/pkg/inject/testdata/authenticator-annotated-pod.json
@@ -6,13 +6,13 @@
       "pod-template-hash": "2710681425"
     },
     "annotations": {
-      "sidecar-injector.cyberark.com/conjurAuthConfig": "conjur",
-      "sidecar-injector.cyberark.com/conjurConnConfig": "conjur",
-      "sidecar-injector.cyberark.com/containerMode": "sidecar",
-      "sidecar-injector.cyberark.com/conjurTokenReceivers": "nginx-2",
-      "sidecar-injector.cyberark.com/inject": "true",
-      "sidecar-injector.cyberark.com/injectType": "authenticator",
-      "sidecar-injector.cyberark.com/containerName": "authenticator-name"
+      "conjur.org/conjurAuthConfig": "conjur",
+      "conjur.org/conjurConnConfig": "conjur",
+      "conjur.org/containerMode": "sidecar",
+      "conjur.org/conjurTokenReceivers": "nginx-2",
+      "conjur.org/inject": "true",
+      "conjur.org/injectType": "authenticator",
+      "conjur.org/containerName": "authenticator-name"
     }
   },
   "spec": {

--- a/pkg/inject/testdata/authenticator-mutated-pod.json
+++ b/pkg/inject/testdata/authenticator-mutated-pod.json
@@ -6,7 +6,7 @@
       "pod-template-hash": "2710681425"
     },
     "annotations": {
-      "sidecar-injector.cyberark.com/status": "injected"
+      "conjur.org/status": "injected"
     }
   },
   "spec": {

--- a/pkg/inject/testdata/secretless-annotated-pod.json
+++ b/pkg/inject/testdata/secretless-annotated-pod.json
@@ -6,11 +6,11 @@
       "pod-template-hash": "2710681425"
     },
     "annotations": {
-      "sidecar-injector.cyberark.com/conjurAuthConfig": "conjur",
-      "sidecar-injector.cyberark.com/conjurConnConfig": "conjur",
-      "sidecar-injector.cyberark.com/secretlessConfig": "secretless-config",
-      "sidecar-injector.cyberark.com/inject": "true",
-      "sidecar-injector.cyberark.com/injectType": "secretless"
+      "conjur.org/conjurAuthConfig": "conjur",
+      "conjur.org/conjurConnConfig": "conjur",
+      "conjur.org/secretlessConfig": "secretless-config",
+      "conjur.org/inject": "true",
+      "conjur.org/injectType": "secretless"
     }
   },
   "spec": {

--- a/pkg/inject/testdata/secretless-mutated-pod.json
+++ b/pkg/inject/testdata/secretless-mutated-pod.json
@@ -6,7 +6,7 @@
       "pod-template-hash": "2710681425"
     },
     "annotations": {
-      "sidecar-injector.cyberark.com/status": "injected"
+      "conjur.org/status": "injected"
     }
   },
   "spec": {

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,6 +1,7 @@
 FROM google/cloud-sdk:latest
 
 ARG HELM_VERSION
+ARG KUBECTL_VERSION=1.22.0
 
 RUN mkdir -p /src
 WORKDIR /src
@@ -20,7 +21,7 @@ RUN apt-get update -y && \
     rm -rf /var/lib/apt/lists/*
 
 # Install kubectl CLI
-RUN wget -O /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.11.3/bin/linux/amd64/kubectl && \
+RUN wget -O /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v"${KUBECTL_VERSION}"/bin/linux/amd64/kubectl && \
     chmod +x /usr/local/bin/kubectl
 
 # Install kubectx and kubens

--- a/tests/echoserver.yaml.sh
+++ b/tests/echoserver.yaml.sh
@@ -111,10 +111,10 @@ spec:
       labels:
         app: sb-sci-echoserver
       annotations:
-        sidecar-injector.cyberark.com/inject: "yes"
-        sidecar-injector.cyberark.com/secretlessConfig: "k8s/crd#crd-basic-auth-proxy"
-        sidecar-injector.cyberark.com/secretlessCRDSuffix: ${SECRETLESS_CRD_SUFFIX}
-        sidecar-injector.cyberark.com/injectType: "secretless"
+        conjur.org/inject: "yes"
+        conjur.org/secretlessConfig: "k8s/crd#crd-basic-auth-proxy"
+        conjur.org/secretlessCRDSuffix: ${SECRETLESS_CRD_SUFFIX}
+        conjur.org/injectType: "secretless"
 
     spec:
       serviceAccountName: secretless-crd-${SECRETLESS_CRD_SUFFIX}


### PR DESCRIPTION
### Desired Outcome

The sidecar-injector is configured using annotations in the Kubernetes manifests, similar
to other projects in Cyberark. The configurable parameters should be consistent across projects. 


### Implemented Changes

Renaming the configurable parameters from **sidecar-injector.cyberark.com** to **conjur.org**
The name of the webhook in the templates is changed to 
sidecar-injector.conjur.org as this requires a domain with at least three segments separated by dots.

Also updated the kubectl version for the test dockerfile.

Note - this is a breaking change, all manifests will need to use the new parameters after this change.

### Connected Issue/Story

CyberArk internal issue link: [ONYX-19422](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-19422)

### Definition of Done

[x] Rename sidecar-injector.cyberark.com to conjur.org
#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [x] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [x] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
