### PR TITLE
Adding basic support for secrets provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.2.0] - 2022-08-02
+
 ### Added
 - Add support for selection of sidecar container versions
   [cyberark/sidecar-injector#71](https://github.com/cyberark/sidecar-injector/pull/71)
+- Add ability to set (and override default) deployment resource `apiVersion` in manifests.
+    [#27](https://github.com/cyberark/sidecar-injector/pull/27)
+- Add support for secrets-provider-for-k8s
+  [cyberark/sidecar-injector#72](https://github.com/cyberark/sidecar-injector/pull/72)
 
 ### Changed
 - Dropped support for Helm V2 and converted to Helm V3.
@@ -20,21 +26,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - BREAKING CHANGE: Changed annotations to be consistent with other Cyberark repositories.
   sidecar-injector.cyberark.com is changed to conjur.org
   All user manifests must be changed to use the new annotations. [cyberark/sidecar-injector#70](https://github.com/cyberark/sidecar-injector/pull/70)
+- Deployment resource `apiVersion` (in manifests) changed from `extensions/v1beta1` to
+  `apps/v1`. [#47](https://github.com/cyberark/sidecar-injector/pull/47)
 
 ### Security
 - Added replace statements to go.mod to remove vulnerable dependency versions from the dependency tree
   [cyberark/sidecar-injector#68](https://github.com/cyberark/sidecar-injector/pull/68)
   [cyberark/sidecar-injector#69](https://github.com/cyberark/sidecar-injector/pull/69)
-
-## [0.1.1] - 2020-06-17
-
-### Added
-- Add ability to set (and override default) deployment resource `apiVersion` in manifests.
-  [#28](https://github.com/cyberark/sidecar-injector/issues/28)
-
-### Changed
-- Deployment resource `apiVersion` (in manifests) changed from `extensions/v1beta1` to
-  `apps/v1`. [#46](https://github.com/cyberark/sidecar-injector/issues/46)
 
 ## [0.1.0] - 2020-05-28
 
@@ -51,6 +49,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Ability to configure the sidecar container images by specifying flags on the sidecar
   injector binary [#29](https://github.com/cyberark/sidecar-injector/issues/29).
 
-[Unreleased]: https://github.com/cyberark/sidecar-injector/compare/v0.1.1...HEAD
-[0.1.1]: https://github.com/cyberark/sidecar-injector/compare/v0.1.0...v0.1.1
+[Unreleased]: https://github.com/cyberark/sidecar-injector/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/cyberark/sidecar-injector/releases/tag/v0.1.0

--- a/bin/test_unit
+++ b/bin/test_unit
@@ -6,14 +6,18 @@ cd $(dirname $0)
 
 function main() {
   build_image
-  run_unit_tests
+  run_unit_tests $1
 }
 
 
 function run_unit_tests() {
   echo "Running unit tests..."
   cd ../pkg/inject
-  go test -v
+  if [ "$1" ]; then
+    go test -v -run $1
+  else
+    go test -v
+  fi
   echo "Unit test exit status: $?"
 }
 
@@ -22,4 +26,4 @@ function build_image() {
   ./build
 }
 
-main
+main $1

--- a/cmd/sidecar-injector/main.go
+++ b/cmd/sidecar-injector/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cyberark/sidecar-injector/pkg/inject"
 	"github.com/cyberark/sidecar-injector/pkg/version"
 )
+// Define environment variables used in Secrets Provider config
 
 func main() {
 	var parameters inject.WebhookServerParameters
@@ -27,6 +28,7 @@ func main() {
 	flag.BoolVar(&parameters.NoHTTPS, "noHTTPS", false, "Run Webhook server as HTTP (not HTTPS).")
 	flag.StringVar(&parameters.SecretlessContainerImage, "secretless-image", "cyberark/secretless-broker:latest", "Container image for the Secretless sidecar")
 	flag.StringVar(&parameters.AuthenticatorContainerImage, "authenticator-image", "cyberark/conjur-kubernetes-authenticator:latest", "Container image for the Kubernetes Authenticator sidecar")
+	flag.StringVar(&parameters.SecretsProviderContainerImage, "secrets-provider-image", "cyberark/secrets-provider-for-k8s:latest", "Container image for the Secrets Provider sidecar")
 
 	// Flag.parse only covers `-version` flag but for `version`, we need to explicitly
 	// check the args

--- a/deployment/deployment.yaml.sh
+++ b/deployment/deployment.yaml.sh
@@ -19,6 +19,10 @@ The following flags are available to configure the sidecar-injector deployment. 
 
        --authenticator-image       Container image for the Kubernetes Authenticator sidecar.
 
+       --secrets-provider-image    Container image for the Secrets Provider sidecar.
+
+       --secrets-provider          Option to use secrets provider and use the conjur-connect config map
+
 EOF
     exit 1
 }
@@ -56,6 +60,16 @@ while [[ $# -gt 0 ]]; do
             authenticatorImageArg="- -authenticator-image=${2}"
             shift
             ;;
+        --secrets-provider-image)
+            usage_if_empty "$2"
+            secretsProviderImageArg="- -secrets-provider-image=${2}"
+            shift
+            ;;
+        --secrets-provider)
+            secretsProvider="envFrom:
+          - configMapRef:
+              name: conjur-connect"
+            ;;
         *)
             usage
             ;;
@@ -90,9 +104,11 @@ spec:
             - -port=8080
             ${authenticatorImageArg}
             ${secretlessImageArg}
+            ${secretsProviderImageArg}
           ports:
             - containerPort: 8080
               name: https
+          ${secretsProvider}
           volumeMounts:
             - name: certs
               mountPath: /etc/webhook/certs

--- a/pkg/inject/authenticator_test.go
+++ b/pkg/inject/authenticator_test.go
@@ -11,9 +11,10 @@ type injectionTestCase struct {
 	description                         string
 	annotatedPodTemplateSpecPath        string
 	expectedInjectedPodTemplateSpecPath string
+	env                                 map[string]string
 }
 
-func TestSidecarInjection(t *testing.T) {
+func TestAuthenticatorSidecarInjection(t *testing.T) {
 	var testCases = []injectionTestCase{
 		{
 			description:                         "Kubernetes Authenticator",
@@ -21,7 +22,7 @@ func TestSidecarInjection(t *testing.T) {
 			expectedInjectedPodTemplateSpecPath: "./testdata/authenticator-mutated-pod.json",
 		},
 		{
-			description:                         "Kubernetes Authenticator",
+			description:                         "Kubernetes Authenticator with image",
 			annotatedPodTemplateSpecPath:        "./testdata/authenticator-annotated-pod-with-image.json",
 			expectedInjectedPodTemplateSpecPath: "./testdata/authenticator-mutated-pod-with-image.json",
 		},

--- a/pkg/inject/constants.go
+++ b/pkg/inject/constants.go
@@ -12,4 +12,18 @@ const (
 	annotationSecretlessCRDSuffixKey  = "conjur.org/secretless-CRD-suffix"
 	annotationStatusKey               = "conjur.org/status"
 	annotationContainerImageKey       = "conjur.org/container-image"
+	annotationSecretsDestinationKey   = "conjur.org/secrets-destination"
 )
+// These annotations are only used for sidecar injector and not passed on to the
+// injected container
+var sidecarInjectorAnnot = []string {
+	annotationConjurAuthConfigKey,
+	annotationConjurConnConfigKey,
+	annotationContainerNameKey,
+	annotationConjurTokenReceiversKey,
+	annotationInjectKey,
+	annotationInjectTypeKey,
+	annotationSecretlessConfigKey,
+	annotationSecretlessCRDSuffixKey,
+	annotationContainerImageKey,
+}

--- a/pkg/inject/patch.go
+++ b/pkg/inject/patch.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -168,26 +167,21 @@ func addVolume(
 func updateAnnotation(
 	target, added map[string]string,
 ) (patch []rfc6902PatchOperation) {
+
 	for key, value := range added {
-		if target == nil || target[key] == "" {
-			target = map[string]string{}
-
-			patch = append(patch, rfc6902PatchOperation{
-				Op:   patchOperationAdd,
-				Path: "/metadata/annotations",
-				Value: map[string]string{
-					key: value,
-				},
-			})
-		} else {
-			patch = append(patch, rfc6902PatchOperation{
-				Op:    patchOperationReplace,
-				Path:  "/metadata/annotations/" + key,
-				Value: value,
-			})
-		}
+		target[key] = value
 	}
+	// Remove annotations that are only for the sidecar injector
+	for _, value := range sidecarInjectorAnnot {
+		delete(target, value)
+    }
+	path := "/metadata/annotations"
 
+	patch = append(patch, rfc6902PatchOperation{
+		Op:    patchOperationAdd,
+		Path:  path,
+		Value: target,
+	})
 	return patch
 }
 

--- a/pkg/inject/secrets-provider.go
+++ b/pkg/inject/secrets-provider.go
@@ -1,0 +1,152 @@
+package inject
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"os"
+)
+
+type SecretsProviderSidecarConfig struct {
+	containerMode           string
+	containerName           string
+	sidecarImage            string
+	secretsDestination      string
+}
+var validEnvVars = []string{
+	"CONJUR_ACCOUNT",
+	"CONJUR_APPLIANCE_URL",
+	"CONJUR_AUTHENTICATOR_ID",
+	"CONJUR_AUTHN_URL",
+	"CONJUR_SSL_CERTIFICATE",
+}
+
+// generateSecretsProviderSidecarConfig generates PatchConfig from a
+// given SecretsProviderSidecarConfig
+func generateSecretsProviderSidecarConfig(
+	cfg SecretsProviderSidecarConfig,
+    ) *PatchConfig {
+	var containers, initContainers []corev1.Container
+	masterMap := make(map[string]string)
+	for _, envVar := range validEnvVars {
+		value := os.Getenv(envVar)
+		if value != "" {
+			masterMap[envVar] = value
+		}
+	}
+
+	volumeMounts := []corev1.VolumeMount{
+		{
+			Name:      "podinfo",
+			ReadOnly:  true,
+			MountPath: "/conjur/podinfo",
+		},
+		{
+			Name:      "conjur-status",
+			ReadOnly:  false,
+			MountPath: "/conjur/status",
+		},
+	}
+	if cfg.secretsDestination == "file" {
+		volumeMount := corev1.VolumeMount{
+			Name:      "conjur-secrets",
+			ReadOnly:  false,
+			MountPath: "/conjur/secrets",
+		}
+		volumeMounts = append(volumeMounts,volumeMount)
+	}
+	container := corev1.Container{
+		Name:            cfg.containerName,
+		Image:           cfg.sidecarImage,
+		ImagePullPolicy: "Always",
+		VolumeMounts: volumeMounts,
+		Env: []corev1.EnvVar{
+			envVarFromFieldPath(
+				"MY_POD_NAME",
+				"metadata.name",
+			),
+			envVarFromFieldPath(
+				"MY_POD_NAMESPACE",
+				"metadata.namespace",
+			),
+			envVarFromLiteral(
+				"CONJUR_ACCOUNT",
+				masterMap["CONJUR_ACCOUNT"],
+			),
+			envVarFromLiteral(
+				"CONJUR_APPLIANCE_URL",
+				masterMap["CONJUR_APPLIANCE_URL"],
+			),
+			envVarFromLiteral(
+				"CONJUR_AUTHENTICATOR_ID",
+				masterMap["CONJUR_AUTHENTICATOR_ID"],
+			),
+			envVarFromLiteral(
+				"CONJUR_AUTHN_URL",
+				masterMap["CONJUR_AUTHN_URL"],
+			),
+			envVarFromLiteral(
+				"CONJUR_SSL_CERTIFICATE",
+				masterMap["CONJUR_SSL_CERTIFICATE"],
+			),
+		},
+	}
+
+	candidates := []corev1.Container{container}
+	if cfg.containerMode == "init" {
+		initContainers = candidates
+	} else {
+		containers = candidates
+	}
+	volumes := getSPVolumes(cfg.secretsDestination)
+
+	return &PatchConfig{
+		Containers:     containers,
+		InitContainers: initContainers,
+		Volumes: volumes,
+	}
+}
+
+func getSPVolumes( secretsDest string ) []corev1.Volume {
+
+	//var vol []corev1.Volume
+	var volume corev1.Volume
+
+	volumes := []corev1.Volume{
+		{
+			Name: "podinfo",
+			VolumeSource: corev1.VolumeSource{
+				DownwardAPI: &corev1.DownwardAPIVolumeSource{
+					Items: []corev1.DownwardAPIVolumeFile{
+						{
+							Path: "annotations",
+							FieldRef: &corev1.ObjectFieldSelector{
+								FieldPath: "metadata.annotations",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "conjur-status",
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{
+					Medium: "Memory",
+				},
+			},
+		},
+	}
+	if secretsDest == "file" {
+		volume = corev1.Volume{
+			Name: "conjur-secrets",
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{
+					Medium: "Memory",
+
+				},
+			},
+		}
+		volumes = append(volumes, volume)
+	}
+	return volumes
+}
+

--- a/pkg/inject/secrets-provider_test.go
+++ b/pkg/inject/secrets-provider_test.go
@@ -1,0 +1,72 @@
+package inject
+
+import (
+	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+
+func TestSecretsProviderSidecarInjection(t *testing.T) {
+	var testCases = []injectionTestCase{
+		{
+			description:                         "SecretsProvider sidecar",
+			annotatedPodTemplateSpecPath:        "./testdata/secrets-provider-annotated-pod.json",
+			expectedInjectedPodTemplateSpecPath: "./testdata/secrets-provider-mutated-pod.json",
+			env: map[string]string{
+				"CONJUR_ACCOUNT":          "myConjurAccount",
+				"CONJUR_APPLIANCE_URL":    "https://conjur-oss.conjur-oss.svc.cluster.local",
+				"CONJUR_AUTHENTICATOR_ID": "my-authenticator-id",
+				"CONJUR_AUTHN_URL":        "https://conjur-oss.conjur-oss.svc.cluster.local/authn-k8s/my-authenticator-id",
+				"CONJUR_SSL_CERTIFICATE":  "-----BEGIN CERTIFICATE-----tVw0ZnjsOV2ZeIBRalX/72RplPzkmWKAw==\n-----END CERTIFICATE-----\n",
+			},
+		},
+		{
+			description:                         "SecretsProvider init",
+			annotatedPodTemplateSpecPath:        "./testdata/secrets-provider-init-annotated-pod.json",
+			expectedInjectedPodTemplateSpecPath: "./testdata/secrets-provider-init-mutated-pod.json",
+			env: map[string]string{
+				"CONJUR_ACCOUNT":          "myConjurAccount",
+				"CONJUR_APPLIANCE_URL":    "https://conjur-oss.conjur-oss.svc.cluster.local",
+				"CONJUR_AUTHENTICATOR_ID": "my-authenticator-id",
+				"CONJUR_AUTHN_URL":        "https://conjur-oss.conjur-oss.svc.cluster.local/authn-k8s/my-authenticator-id",
+				"CONJUR_SSL_CERTIFICATE":  "-----BEGIN CERTIFICATE-----tVw0ZnjsOV2ZeIBRalX/72RplPzkmWKAw==\n-----END CERTIFICATE-----\n",
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			for envVar, value := range tc.env {
+				os.Setenv(envVar, value)
+			}
+			// Create the Admission Request (wrapped in an Admission Review) from the
+			// annotated pod fixture. The goal is to use the annotations as a signal to
+			// the sidecar-injector to mutate the Pod template spec.
+			req, err := newTestAdmissionRequest(
+				tc.annotatedPodTemplateSpecPath,
+			)
+			if !assert.NoError(t, err) {
+				return
+			}
+
+			// Read the expected Pod template spec fixture.
+			expectedMod, err := ioutil.ReadFile(
+				tc.expectedInjectedPodTemplateSpecPath,
+			)
+			if !assert.NoError(t, err) {
+				return
+			}
+
+			// Get the modified Pod template spec from the input.
+			mod, err := applyPatchToAdmissionRequest(req)
+			if !assert.NoError(t, err) {
+				return
+			}
+
+			// Assert that the modified Pod template spec should equal the expected Pod
+			// template spec.
+			assert.JSONEq(t, string(expectedMod), string(mod))
+		})
+	}
+}

--- a/pkg/inject/testdata/authenticator-mutated-pod-with-image.json
+++ b/pkg/inject/testdata/authenticator-mutated-pod-with-image.json
@@ -6,6 +6,7 @@
       "pod-template-hash": "2710681425"
     },
     "annotations": {
+      "conjur.org/container-mode": "sidecar",
       "conjur.org/status": "injected"
     }
   },

--- a/pkg/inject/testdata/authenticator-mutated-pod.json
+++ b/pkg/inject/testdata/authenticator-mutated-pod.json
@@ -6,6 +6,7 @@
       "pod-template-hash": "2710681425"
     },
     "annotations": {
+      "conjur.org/container-mode": "sidecar",
       "conjur.org/status": "injected"
     }
   },

--- a/pkg/inject/testdata/secrets-provider-annotated-pod.json
+++ b/pkg/inject/testdata/secrets-provider-annotated-pod.json
@@ -1,0 +1,41 @@
+{
+  "metadata": {
+    "generateName": "nginx-deployment-6c54bd5869-",
+    "labels": {
+      "app": "nginx",
+      "pod-template-hash": "2710681425"
+    },
+    "annotations": {
+      "conjur.org/inject": "true",
+      "conjur.org/inject-type": "secrets-provider",
+      "conjur.org/container-name" : "secrets-provider-name",
+      "conjur.org/container-mode": "sidecar",
+      "conjur.org/secrets-destination": "file",
+      "conjur.org/conjur-token-receivers": "nginx-1",
+      "my-company": "my-project"
+    }
+  },
+  "spec": {
+    "volumes": [
+      {
+        "name": "default-token-tq5lq",
+        "secret": {
+          "secretName": "default-token-tq5lq"
+        }
+      }
+    ],
+    "containers": [
+      {
+        "name": "nginx-1",
+        "image": "nginx:1.7.9",
+        "volumeMounts": [
+          {
+            "name": "default-token-tq5lq",
+            "readOnly": true,
+            "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/pkg/inject/testdata/secrets-provider-init-annotated-pod.json
+++ b/pkg/inject/testdata/secrets-provider-init-annotated-pod.json
@@ -1,0 +1,41 @@
+{
+  "metadata": {
+    "generateName": "nginx-deployment-6c54bd5869-",
+    "labels": {
+      "app": "nginx",
+      "pod-template-hash": "2710681425"
+    },
+    "annotations": {
+      "conjur.org/inject": "true",
+      "conjur.org/inject-type": "secrets-provider",
+      "conjur.org/container-name" : "secrets-provider-name",
+      "conjur.org/container-mode": "init",
+      "conjur.org/secrets-destination": "file",
+      "conjur.org/conjur-token-receivers": "nginx-1",
+      "my-company": "my-project"
+    }
+  },
+  "spec": {
+    "volumes": [
+      {
+        "name": "default-token-tq5lq",
+        "secret": {
+          "secretName": "default-token-tq5lq"
+        }
+      }
+    ],
+    "containers": [
+      {
+        "name": "nginx-1",
+        "image": "nginx:1.7.9",
+        "volumeMounts": [
+          {
+            "name": "default-token-tq5lq",
+            "readOnly": true,
+            "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/pkg/inject/testdata/secrets-provider-init-mutated-pod.json
+++ b/pkg/inject/testdata/secrets-provider-init-mutated-pod.json
@@ -1,0 +1,132 @@
+{
+  "metadata": {
+    "generateName": "nginx-deployment-6c54bd5869-",
+    "labels": {
+      "app": "nginx",
+      "pod-template-hash": "2710681425"
+    },
+    "annotations": {
+      "conjur.org/container-mode": "init",
+      "conjur.org/secrets-destination": "file",
+      "my-company": "my-project",
+      "conjur.org/status": "injected"
+    }
+  },
+  "spec": {
+    "volumes": [
+      {
+        "name": "default-token-tq5lq",
+        "secret": {
+          "secretName": "default-token-tq5lq"
+        }
+      },
+      {
+        "name": "podinfo",
+        "downwardAPI": {
+          "items": [
+            {
+              "path": "annotations",
+              "fieldRef": {
+                "fieldPath": "metadata.annotations"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "name": "conjur-status",
+        "emptyDir": {
+          "medium": "Memory"
+        }
+      },
+      {
+        "name": "conjur-secrets",
+        "emptyDir": {
+          "medium": "Memory"
+        }
+      }
+    ],
+    "containers": [
+      {
+        "name": "nginx-1",
+        "image": "nginx:1.7.9",
+        "volumeMounts": [
+          {
+            "name": "default-token-tq5lq",
+            "readOnly": true,
+            "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+          },
+          {
+            "name": "conjur-status",
+            "mountPath": "/conjur/status"
+          },
+          {
+            "name": "conjur-secrets",
+            "mountPath": "/conjur/secrets"
+          }
+        ]
+      }
+    ],
+    "initContainers": [
+      {
+        "name": "secrets-provider-name",
+        "image": "secrets-provider-image",
+        "resources": {},
+        "imagePullPolicy": "Always",
+        "env": [
+          {
+            "name": "MY_POD_NAME",
+            "valueFrom": {
+              "fieldRef": {
+                "fieldPath": "metadata.name"
+              }
+            }
+          },
+          {
+            "name": "MY_POD_NAMESPACE",
+            "valueFrom": {
+              "fieldRef": {
+                "fieldPath": "metadata.namespace"
+              }
+            }
+          },
+          {
+            "name": "CONJUR_ACCOUNT",
+            "value": "myConjurAccount"
+          },
+          {
+            "name": "CONJUR_APPLIANCE_URL",
+            "value": "https://conjur-oss.conjur-oss.svc.cluster.local"
+          },
+          {
+            "name": "CONJUR_AUTHENTICATOR_ID",
+            "value": "my-authenticator-id"
+          },
+          {
+            "name": "CONJUR_AUTHN_URL",
+            "value": "https://conjur-oss.conjur-oss.svc.cluster.local/authn-k8s/my-authenticator-id"
+          },
+          {
+            "name": "CONJUR_SSL_CERTIFICATE",
+            "value": "-----BEGIN CERTIFICATE-----tVw0ZnjsOV2ZeIBRalX/72RplPzkmWKAw==\n-----END CERTIFICATE-----\n"
+          }
+        ],
+        "volumeMounts": [
+          {
+            "name": "podinfo",
+            "readOnly": true,
+            "mountPath": "/conjur/podinfo"
+          },
+          {
+            "name": "conjur-status",
+            "mountPath": "/conjur/status"
+          },
+          {
+            "name": "conjur-secrets",
+            "mountPath": "/conjur/secrets"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/pkg/inject/testdata/secrets-provider-mutated-pod.json
+++ b/pkg/inject/testdata/secrets-provider-mutated-pod.json
@@ -1,0 +1,130 @@
+{
+  "metadata": {
+    "generateName": "nginx-deployment-6c54bd5869-",
+    "labels": {
+      "app": "nginx",
+      "pod-template-hash": "2710681425"
+    },
+    "annotations": {
+      "conjur.org/container-mode": "sidecar",
+      "conjur.org/secrets-destination": "file",
+      "my-company": "my-project",
+      "conjur.org/status": "injected"
+    }
+  },
+  "spec": {
+    "volumes": [
+      {
+        "name": "default-token-tq5lq",
+        "secret": {
+          "secretName": "default-token-tq5lq"
+        }
+      },
+      {
+        "name": "podinfo",
+        "downwardAPI": {
+          "items": [
+             {
+              "path": "annotations",
+              "fieldRef": {
+                "fieldPath": "metadata.annotations"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "name": "conjur-status",
+        "emptyDir": {
+          "medium": "Memory"
+        }
+      },
+      {
+        "name": "conjur-secrets",
+        "emptyDir": {
+          "medium": "Memory"
+        }
+      }
+    ],
+    "containers": [
+      {
+        "name": "nginx-1",
+        "image": "nginx:1.7.9",
+        "volumeMounts": [
+          {
+            "name": "default-token-tq5lq",
+            "readOnly": true,
+            "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+          },
+          {
+            "name": "conjur-status",
+            "mountPath": "/conjur/status"
+          },
+          {
+            "name": "conjur-secrets",
+            "mountPath": "/conjur/secrets"
+          }
+        ]
+      },
+      {
+        "name": "secrets-provider-name",
+        "image": "secrets-provider-image",
+        "resources": {},
+        "imagePullPolicy": "Always",
+        "env": [
+          {
+            "name": "MY_POD_NAME",
+            "valueFrom": {
+              "fieldRef": {
+                "fieldPath": "metadata.name"
+              }
+            }
+          },
+          {
+            "name": "MY_POD_NAMESPACE",
+            "valueFrom": {
+              "fieldRef": {
+                "fieldPath": "metadata.namespace"
+              }
+            }
+          },
+          {
+            "name": "CONJUR_ACCOUNT",
+            "value": "myConjurAccount"
+          },
+          {
+            "name": "CONJUR_APPLIANCE_URL",
+            "value": "https://conjur-oss.conjur-oss.svc.cluster.local"
+          },
+          {
+            "name": "CONJUR_AUTHENTICATOR_ID",
+            "value": "my-authenticator-id"
+          },
+          {
+            "name": "CONJUR_AUTHN_URL",
+            "value": "https://conjur-oss.conjur-oss.svc.cluster.local/authn-k8s/my-authenticator-id"
+          },
+          {
+            "name": "CONJUR_SSL_CERTIFICATE",
+            "value": "-----BEGIN CERTIFICATE-----tVw0ZnjsOV2ZeIBRalX/72RplPzkmWKAw==\n-----END CERTIFICATE-----\n"
+          }
+        ],
+        "volumeMounts": [
+          {
+            "name": "podinfo",
+            "readOnly": true,
+            "mountPath": "/conjur/podinfo"
+          },
+          {
+            "name": "conjur-status",
+            "mountPath": "/conjur/status"
+          },
+          {
+            "name": "conjur-secrets",
+            "mountPath": "/conjur/secrets"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/pkg/inject/utils_test.go
+++ b/pkg/inject/utils_test.go
@@ -19,8 +19,9 @@ func applyPatchToAdmissionRequest(reviewRequestBytes []byte) ([]byte, error) {
 	}
 	admissionRes := HandleAdmissionRequest(
 		SidecarInjectorConfig{
-			SecretlessContainerImage:    "secretless-image",
-			AuthenticatorContainerImage: "authenticator-image",
+			SecretlessContainerImage:      "secretless-image",
+			AuthenticatorContainerImage:   "authenticator-image",
+			SecretsProviderContainerImage: "secrets-provider-image",
 		},
 		req,
 	)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -3,7 +3,7 @@ package version
 import "fmt"
 
 // gitVersion is a SemVer that captures the baked-in version of the sidecar-injector.
-const gitVersion = "0.1.1"
+const gitVersion = "0.2.0"
 
 // gitCommitShort denotes the specific build type for the sidecar-injector. It defaults to the
 // special value 'dev'. It is expected to be replaced by the compile-time value of the


### PR DESCRIPTION
### Desired Outcome

The sidecar injector should support secrets-provider-provider-for-k8s 

### Implemented Changes

Adds minimal basic support for secrets-provider-provider-for-k8s with push to file configuration.
More will be added on follow up commits.


### Connected Issue/Story

CyberArk internal issue link: [ONYX-19424](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-19424)

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [x] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [x] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
