### PR TITLE
Add support for reading the golden configmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add support for selection of sidecar container versions
   [cyberark/sidecar-injector#71](https://github.com/cyberark/sidecar-injector/pull/71)
 - Add ability to set (and override default) deployment resource `apiVersion` in manifests.
-    [#27](https://github.com/cyberark/sidecar-injector/pull/27)
-- Add support for secrets-provider-for-k8s
-  [cyberark/sidecar-injector#72](https://github.com/cyberark/sidecar-injector/pull/72)
+    [cyberark/sidecar-injector#27](https://github.com/cyberark/sidecar-injector/pull/27)
+- Add support for secrets-provider-for-k8s<br>
+  [cyberark/sidecar-injector#72](https://github.com/cyberark/sidecar-injector/pull/72) <br>
+  [cyberark/sidecar-injector#73](https://github.com/cyberark/sidecar-injector/pull/73) <br>
 
 ### Changed
 - Dropped support for Helm V2 and converted to Helm V3.

--- a/README.md
+++ b/README.md
@@ -121,13 +121,14 @@ Injects:
   + **Volume Mounts** at `/conjur/secrets` and `/conjur/podinfo`
 
 Requires:
-  + a conjur-connect configMap in the namespace that the sidecar resides in.
-  + The sidecar deployment manifest must include the conjur-connect configmap
+  + a configMap in the namespace that the sidecar resides in. The config map can be the Golden config or the Conjur connect config map.
+  + The sidecar deployment manifest must include the conjur-connect configmap or the Golden configmap
 
+For example to add the Golden config to the sidecar manifest:
 ```
     envFrom:
       - configMapRef:
-          name: conjur-connect
+          name: conjur-configmap
 ```
 
 ### Mandatory TLS

--- a/pkg/inject/secrets-provider_test.go
+++ b/pkg/inject/secrets-provider_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 )
 
-
 func TestSecretsProviderSidecarInjection(t *testing.T) {
 	var testCases = []injectionTestCase{
 		{
@@ -32,6 +31,17 @@ func TestSecretsProviderSidecarInjection(t *testing.T) {
 				"CONJUR_AUTHENTICATOR_ID": "my-authenticator-id",
 				"CONJUR_AUTHN_URL":        "https://conjur-oss.conjur-oss.svc.cluster.local/authn-k8s/my-authenticator-id",
 				"CONJUR_SSL_CERTIFICATE":  "-----BEGIN CERTIFICATE-----tVw0ZnjsOV2ZeIBRalX/72RplPzkmWKAw==\n-----END CERTIFICATE-----\n",
+			},
+		},
+		{
+			description:                         "SecretsProvider golden config",
+			annotatedPodTemplateSpecPath:        "./testdata/secrets-provider-annotated-pod.json",
+			expectedInjectedPodTemplateSpecPath: "./testdata/secrets-provider-mutated-pod.json",
+			env: map[string]string{
+				"conjurAccount":           "myConjurAccount",
+				"conjurApplianceUrl":      "https://conjur-oss.conjur-oss.svc.cluster.local",
+				"authnK8sAuthenticatorID": "my-authenticator-id",
+				"conjurSslCertificate":    "-----BEGIN CERTIFICATE-----tVw0ZnjsOV2ZeIBRalX/72RplPzkmWKAw==\n-----END CERTIFICATE-----\n",
 			},
 		},
 	}
@@ -67,6 +77,9 @@ func TestSecretsProviderSidecarInjection(t *testing.T) {
 			// Assert that the modified Pod template spec should equal the expected Pod
 			// template spec.
 			assert.JSONEq(t, string(expectedMod), string(mod))
+			for envVar, _ := range tc.env {
+				os.Unsetenv(envVar)
+			}
 		})
 	}
 }


### PR DESCRIPTION
### Desired Outcome

The sidecar injector should read the Golden Configmap.

### Implemented Changes

Added checks for the variables in the Golden config, while still maintaining support
for the conjur-connect style config. If both style env variables are present
the conjur-connect style is preferred.

The sidecar injector can be configured in three ways.
- reading from the Golden Config config map
- reading from the Conjur Connect config map
- the variables can be added individually is the user chooses.

### Connected Issue/Story

CyberArk internal issue link: [ONYX-19423](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-19423)

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [x] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
