### PR TITLE
POC to add security context values

### DIFF
--- a/pkg/inject/constants.go
+++ b/pkg/inject/constants.go
@@ -13,6 +13,7 @@ const (
 	annotationStatusKey               = "conjur.org/status"
 	annotationContainerImageKey       = "conjur.org/container-image"
 	annotationSecretsDestinationKey   = "conjur.org/secrets-destination"
+	annotationRunAsUser               = "conjur.org/run-as-user"
 )
 // These annotations are only used for sidecar injector and not passed on to the
 // injected container
@@ -26,4 +27,5 @@ var sidecarInjectorAnnot = []string {
 	annotationSecretlessConfigKey,
 	annotationSecretlessCRDSuffixKey,
 	annotationContainerImageKey,
+	annotationRunAsUser,
 }

--- a/pkg/inject/server.go
+++ b/pkg/inject/server.go
@@ -290,12 +290,17 @@ func HandleAdmissionRequest(
 			&pod.ObjectMeta,
 			annotationSecretsDestinationKey,
 		)
+		runAsUser, err := getAnnotation(
+			&pod.ObjectMeta,
+			annotationRunAsUser,
+		)
 		sidecarConfig = generateSecretsProviderSidecarConfig(
 			SecretsProviderSidecarConfig{
 				containerMode: containerMode,
 				containerName: containerName,
 				sidecarImage: containerImage,
 				secretsDestination: secretsDestination,
+				runAsUser: runAsUser,
 			},
 		)
 		containerVolumeMounts := ContainerVolumeMounts{}

--- a/pkg/inject/testdata/secrets-provider-init-mutated-pod.json
+++ b/pkg/inject/testdata/secrets-provider-init-mutated-pod.json
@@ -73,6 +73,9 @@
         "image": "secrets-provider-image",
         "resources": {},
         "imagePullPolicy": "Always",
+        "securityContext": {
+          "runAsUser": 1234
+        },
         "env": [
           {
             "name": "MY_POD_NAME",

--- a/pkg/inject/testdata/secrets-provider-mutated-pod.json
+++ b/pkg/inject/testdata/secrets-provider-mutated-pod.json
@@ -71,6 +71,9 @@
         "image": "secrets-provider-image",
         "resources": {},
         "imagePullPolicy": "Always",
+        "securityContext": {
+          "runAsUser": 1234
+        },
         "env": [
           {
             "name": "MY_POD_NAME",


### PR DESCRIPTION
### Desired Outcome

In some Openshift environments the Secrets Provider and application need to run as the same
user ID for the Sentinel files to work correctly.



### Implemented Changes

Adding a new sidecar annotation to allow the injector to add the security context,
some questions remain.

- Should we always write the security context? or only when the annotation is present
- Should we have a user defined default value, if so does it go in a config map or start up parameter.
- Should we include other security context values?


### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue link: [ONYX-25163](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-25163)

### Definition of Done



#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [x] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
