### PR TITLE
Rename conjur token receivers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   All user manifests must be changed to use the new annotations. [cyberark/sidecar-injector#70](https://github.com/cyberark/sidecar-injector/pull/70)
 - Deployment resource `apiVersion` (in manifests) changed from `extensions/v1beta1` to
   `apps/v1`. [#47](https://github.com/cyberark/sidecar-injector/pull/47)
+- BREAKING CHANGE: Changed annotation `conjur-token-receivers` to `conjur-inject-volumes` for compatability
+  with Secrets Provider [cyberark/sidecar-injector#76](https://github.com/cyberark/sidecar-injector/pull/76)
 
 ### Security
 - Added replace statements to go.mod to remove vulnerable dependency versions from the dependency tree

--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ default values.
 | `conjur.org/conjurAuthConfig` | ConfigMap holding Conjur authentication configuration            |  `nil` (required for authenticator |
 | `conjur.org/conjurConnConfig` | ConfigMap holding Conjur connection configuration               |  `nil` (required for authenticator |
 | `conjur.org/inject-type` | Injected Sidecar type (`secretless`, `authenticator` or `secrets-provider`)                    |  `nil` (required) |
-| `conjur.org/conjur-token-receivers` | Comma-separated list of the names of containers, in the pod, that will be injected with `conjur-access-token` VolumeMounts. (e.g. `app-container-1,app-container-2`)                  |  `nil` (only applies to authenticator) |
+| `conjur.org/conjur-inject-volumes` | Comma-separated list of the names of containers, in the pod, that will be injected with `conjur-access-token` or `conjur-secrets` and `conjur-status` VolumeMounts. (e.g. `app-container-1,app-container-2`)                  |  `nil` (applies to authenticator and secrets provider) |
 | `conjur.org/container-mode` | Sidecar Container mode (`init` or `sidecar`)                  | (secretless only supports sidecar) defaults to `sidecar` |
 | `conjur.org/container-name` | Sidecar Container name                  |  `nil` (only applies to authenticator and secrets-provider)                              |
 | `conjur.org/container-image` | Sidecar Container image      | defaults to the value configured for the sidecar-injector at startup, using the `-secretless-image` or `-authenticator-image` or `-secrets-provider` CLI arguments. |

--- a/pkg/inject/constants.go
+++ b/pkg/inject/constants.go
@@ -5,7 +5,7 @@ const (
 	annotationConjurConnConfigKey     = "conjur.org/conjurConnConfig"
 	annotationContainerNameKey        = "conjur.org/container-name"
 	annotationContainerModeKey        = "conjur.org/container-mode"
-	annotationConjurTokenReceiversKey = "conjur.org/conjur-token-receivers"
+	annotationConjurInjectVolumesKey = "conjur.org/conjur-inject-volumes"
 	annotationInjectKey               = "conjur.org/inject"
 	annotationInjectTypeKey           = "conjur.org/inject-type"
 	annotationSecretlessConfigKey     = "conjur.org/secretless-config"
@@ -20,7 +20,7 @@ var sidecarInjectorAnnot = []string {
 	annotationConjurAuthConfigKey,
 	annotationConjurConnConfigKey,
 	annotationContainerNameKey,
-	annotationConjurTokenReceiversKey,
+	annotationConjurInjectVolumesKey,
 	annotationInjectKey,
 	annotationInjectTypeKey,
 	annotationSecretlessConfigKey,

--- a/pkg/inject/server.go
+++ b/pkg/inject/server.go
@@ -115,13 +115,13 @@ func HandleAdmissionRequest(
 	injectType, err := getAnnotation(&pod.ObjectMeta, annotationInjectTypeKey)
 	containerMode, err := getAnnotation(&pod.ObjectMeta, annotationContainerModeKey)
 	containerName, err := getAnnotation(&pod.ObjectMeta, annotationContainerNameKey)
-	conjurTokenReceiversStr, err := getAnnotation(
+	conjurInjectVolumeStr, err := getAnnotation(
 		&pod.ObjectMeta,
-		annotationConjurTokenReceiversKey,
+		annotationConjurInjectVolumesKey,
 	)
-	conjurTokenReceivers := strings.Split(conjurTokenReceiversStr, ",")
-	for i := range conjurTokenReceivers {
-		conjurTokenReceivers[i] = strings.TrimSpace(conjurTokenReceivers[i])
+	conjurInjectVolume := strings.Split(conjurInjectVolumeStr, ",")
+	for i := range conjurInjectVolume {
+		conjurInjectVolume[i] = strings.TrimSpace(conjurInjectVolume[i])
 	}
 	var sidecarConfig *PatchConfig
 	annotations := make(map[string]string)
@@ -251,7 +251,7 @@ func HandleAdmissionRequest(
 		})
 
 		containerVolumeMounts := ContainerVolumeMounts{}
-		for _, receiveContainerName := range conjurTokenReceivers {
+		for _, receiveContainerName := range conjurInjectVolume {
 			containerVolumeMounts[receiveContainerName] = []corev1.VolumeMount{
 				{
 					Name:      "conjur-access-token",
@@ -299,12 +299,8 @@ func HandleAdmissionRequest(
 			},
 		)
 		containerVolumeMounts := ContainerVolumeMounts{}
-		// Here we are using the "conjur.org/conjur-token-receivers" annotation
-		// We need to either
-		// a - rename this annotation to a common name
-		// b - add a similar annotation for Secrets Provider
-		// c - add the volume mount to all containers
-		for _, receiveContainerName := range conjurTokenReceivers {
+
+		for _, receiveContainerName := range conjurInjectVolume {
 			containerVolumeMounts[receiveContainerName] = []corev1.VolumeMount{
 				{
 					Name:      "conjur-status",

--- a/pkg/inject/testdata/authenticator-annotated-pod-with-image.json
+++ b/pkg/inject/testdata/authenticator-annotated-pod-with-image.json
@@ -9,7 +9,7 @@
       "conjur.org/conjurAuthConfig": "conjur",
       "conjur.org/conjurConnConfig": "conjur",
       "conjur.org/container-mode": "sidecar",
-      "conjur.org/conjur-token-receivers": "nginx-2",
+      "conjur.org/conjur-inject-volumes": "nginx-2",
       "conjur.org/inject": "true",
       "conjur.org/inject-type": "authenticator",
       "conjur.org/container-name": "authenticator-name",

--- a/pkg/inject/testdata/authenticator-annotated-pod.json
+++ b/pkg/inject/testdata/authenticator-annotated-pod.json
@@ -9,7 +9,7 @@
       "conjur.org/conjurAuthConfig": "conjur",
       "conjur.org/conjurConnConfig": "conjur",
       "conjur.org/container-mode": "sidecar",
-      "conjur.org/conjur-token-receivers": "nginx-2",
+      "conjur.org/conjur-inject-volumes": "nginx-2",
       "conjur.org/inject": "true",
       "conjur.org/inject-type": "authenticator",
       "conjur.org/container-name": "authenticator-name"

--- a/pkg/inject/testdata/secrets-provider-annotated-pod.json
+++ b/pkg/inject/testdata/secrets-provider-annotated-pod.json
@@ -11,7 +11,7 @@
       "conjur.org/container-name" : "secrets-provider-name",
       "conjur.org/container-mode": "sidecar",
       "conjur.org/secrets-destination": "file",
-      "conjur.org/conjur-token-receivers": "nginx-1",
+      "conjur.org/conjur-inject-volumes": "nginx-1",
       "my-company": "my-project"
     }
   },

--- a/pkg/inject/testdata/secrets-provider-init-annotated-pod.json
+++ b/pkg/inject/testdata/secrets-provider-init-annotated-pod.json
@@ -11,7 +11,7 @@
       "conjur.org/container-name" : "secrets-provider-name",
       "conjur.org/container-mode": "init",
       "conjur.org/secrets-destination": "file",
-      "conjur.org/conjur-token-receivers": "nginx-1",
+      "conjur.org/conjur-inject-volumes": "nginx-1",
       "my-company": "my-project"
     }
   },


### PR DESCRIPTION
### Desired Outcome

The sidecar injector currently uses the annotation `conjur.org/conjur-token-receivers`
for the authenticator to specify which application containers should have a shared volume added
to it. Secrets Provider also needs to add a shared volume to the application, but for the Secrets Provider
it is `conjur-secrets` and `conjur-status`.

### Implemented Changes

Renamed "conjur.org/conjur-token-receivers" to  "conjur.org/conjur-inject-volumes"
### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue link: [insert issue ID]()

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [x] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
