### PR TITLE
Add replace for golang.org/x/crypto@v0.0.0-20210921155107-089bfa567519

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   with Secrets Provider [cyberark/sidecar-injector#76](https://github.com/cyberark/sidecar-injector/pull/76)
 
 ### Security
+- Added replace statement for golang.org/x/crypto@v0.0.0-20210921155107-089bfa567519
+  [cyberark/sidecar-injector#80](https://github.com/cyberark/sidecar-injector/pull/80)
 - Updated replace statements to force golang.org/x/net v0.0.0-20220923203811-8be639271d50
    and updated testify to 1.8.0 [cyberark/sidecar-injector#78](https://github.com/cyberark/sidecar-injector/pull/78)
 - Added replace statements to go.mod to remove vulnerable dependency versions from the dependency tree

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,8 @@ replace golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 => golang.org/x/c
 
 replace golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 => golang.org/x/crypto v0.0.0-20220314234659-1baeb1ce4c0b
 
+replace golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 => golang.org/x/crypto v0.0.0-20220314234659-1baeb1ce4c0b
+
 replace golang.org/x/net v0.0.0-20180724234803-3673e40ba225 => golang.org/x/net v0.0.0-20220923203811-8be639271d50
 
 replace golang.org/x/net v0.0.0-20180826012351-8a410e7b638d => golang.org/x/net v0.0.0-20220923203811-8be639271d50


### PR DESCRIPTION
Signed-off-by: Andy Tinkham <andy.tinkham@cyberark.com>

### Desired Outcome

Prune golang.org/x/crypto@v0.0.0-20210921155107-089bfa567519 from dep tree

### Implemented Changes

Added replace statement to force to golang.org/x/crypto@v0.0.0-20220314234659-1baeb1ce4c0b