### PR TITLE
Adding serviceaccountsecret

### DIFF
--- a/helm/cyberark-sidecar-injector/templates/serviceaccountsecret.yaml
+++ b/helm/cyberark-sidecar-injector/templates/serviceaccountsecret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/service-account-token
+metadata:
+  name: {{ include "cyberark-sidecar-injector.name" . }}-service-account-token
+  labels:
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+  annotations:
+    kubernetes.io/service-account.name: {{ include "cyberark-sidecar-injector.name" . }}


### PR DESCRIPTION


### Desired Outcome

With K8S 1.24 a secret is no longer created automatically with a service account, it needs to be created.
K8s service needs a secret added as it is no longer created automatically.


### Implemented Changes

added serviceaccountsecret.yaml in the Helm chart

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue link: [insert issue ID]()

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
